### PR TITLE
[#44] Beautify the default color scheme

### DIFF
--- a/com.reprezen.swagedit.target.kepler/com.reprezen.swagedit.target.kepler.target
+++ b/com.reprezen.swagedit.target.kepler/com.reprezen.swagedit.target.kepler.target
@@ -25,10 +25,6 @@
 <unit id="org.mockito" version="1.9.5.v201311280930"/>
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20150821153341/repository/"/>
 </location>
-<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="com.github.eclipsecolortheme.feature.feature.group" version="1.0.0.201410260308"/>
-<repository location="http://eclipse-color-theme.github.io/update/"/>
-</location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 </target>

--- a/com.reprezen.swagedit.target.kepler/com.reprezen.swagedit.target.kepler.target
+++ b/com.reprezen.swagedit.target.kepler/com.reprezen.swagedit.target.kepler.target
@@ -25,6 +25,10 @@
 <unit id="org.mockito" version="1.9.5.v201311280930"/>
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20150821153341/repository/"/>
 </location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.github.eclipsecolortheme.feature.feature.group" version="1.0.0.201410260308"/>
+<repository location="http://eclipse-color-theme.github.io/update/"/>
+</location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
 </target>

--- a/com.reprezen.swagedit.target/com.reprezen.swagedit.target.target
+++ b/com.reprezen.swagedit.target/com.reprezen.swagedit.target.target
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<?pde version="3.8"?><target name="com.reprezen.swagedit.target" sequenceNumber="4">
+<?pde version="3.8"?><target name="com.reprezen.swagedit.target" sequenceNumber="5">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
 <unit id="org.eclipse.rcp.feature.group" version="4.4.2.v20150204-1700"/>
@@ -25,6 +25,10 @@
 <unit id="org.mockito" version="1.9.5.v201311280930"/>
 <unit id="org.hamcrest.library" version="1.3.0.v201505072020"/>
 <repository location="http://download.eclipse.org/tools/orbit/downloads/drops/R20150821153341/repository/"/>
+</location>
+<location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
+<unit id="com.github.eclipsecolortheme.feature.feature.group" version="1.0.0.201410260308"/>
+<repository location="http://eclipse-color-theme.github.io/update/"/>
 </location>
 </locations>
 <targetJRE path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>

--- a/com.reprezen.swagedit/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit/META-INF/MANIFEST.MF
@@ -12,7 +12,8 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.ui.ide,
  org.eclipse.ui.workbench.texteditor,
- org.dadacoalition.yedit;bundle-version="1.0.20"
+ org.dadacoalition.yedit;bundle-version="1.0.20",
+ com.github.eclipsecolortheme;resolution:=optional
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ClassPath: lib/cal10n.api_0.7.4.jar,

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -83,4 +83,20 @@
       <include file="resources/templates.xml"></include>
    </extension>
 
+   <extension
+         point="org.eclipse.core.runtime.preferences">
+      <initializer
+            class="com.reprezen.swagedit.preferences.SwaggerPreferenceInitializer">
+      </initializer>
+   </extension>
+
+	<extension point="com.github.eclipsecolortheme.mapper">
+	   <mapper
+	         class="com.github.eclipsecolortheme.mapper.GenericMapper"
+	         name="SwagEdit"
+	         pluginId="com.reprezen.swagedit"
+	         xml="resources/com.reprezen.swagedit.xml">
+	   </mapper>
+   </extension>
+
 </plugin>

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -90,13 +90,13 @@
       </initializer>
    </extension>
 
-	<extension point="com.github.eclipsecolortheme.mapper">
-	   <mapper
-	         class="com.github.eclipsecolortheme.mapper.GenericMapper"
-	         name="SwagEdit"
-	         pluginId="com.reprezen.swagedit"
-	         xml="resources/com.reprezen.swagedit.xml">
-	   </mapper>
-   </extension>
+   <extension point="com.github.eclipsecolortheme.mapper">
+       <mapper
+           class="com.github.eclipsecolortheme.mapper.GenericMapper"
+           name="SwagEdit"
+           pluginId="com.reprezen.swagedit"
+           xml="resources/com.reprezen.swagedit.xml">
+           </mapper>
+    </extension>
 
 </plugin>

--- a/com.reprezen.swagedit/resources/com.reprezen.swagedit.xml
+++ b/com.reprezen.swagedit/resources/com.reprezen.swagedit.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<eclipseColorThemeMapping 
+	plugin="com.reprezen.swagedit"
+	created="2016-01-15 10:00:00">
+	<mappings>
+		<mapping pluginKey="colorCommentPreference" themeKey="singleLineComment" />
+		<mapping pluginKey="colorKeyPreference" themeKey="method" />
+		<mapping pluginKey="colorScalarPreference" themeKey="string" />
+		<mapping pluginKey="colorDefaultPreference" themeKey="foreground" />
+		<mapping pluginKey="colorDocumentPreference" themeKey="foreground" />
+		<mapping pluginKey="colorAnchorPreferences" themeKey="foreground" />
+		<mapping pluginKey="colorAliasPreferences" themeKey="foreground" />
+		<mapping pluginKey="colorTagPropertyPreferences" themeKey="foreground" />
+		<mapping pluginKey="colorFlowCharacterPreferences" themeKey="foreground" />
+		<mapping pluginKey="colorConstantPreferences" themeKey="method" />
+	</mappings>
+</eclipseColorThemeMapping>

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerDocumentProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerDocumentProvider.java
@@ -3,13 +3,13 @@ package com.reprezen.swagedit.editor;
 import java.util.Set;
 
 import org.dadacoalition.yedit.editor.ColorManager;
-import org.dadacoalition.yedit.editor.scanner.YAMLScanner;
 import org.dadacoalition.yedit.editor.scanner.YAMLToken;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.rules.FastPartitioner;
-import org.eclipse.jface.text.rules.IPartitionTokenScanner;
 import org.eclipse.ui.editors.text.FileDocumentProvider;
+
+import com.reprezen.swagedit.Activator;
 
 public class SwaggerDocumentProvider extends FileDocumentProvider {
 
@@ -17,7 +17,7 @@ public class SwaggerDocumentProvider extends FileDocumentProvider {
 	protected IDocument createDocument(Object element) throws CoreException {
 		IDocument document = super.createDocument(element);
 		if (document != null) {
-			SwaggerPartitionScanner scanner = new SwaggerPartitionScanner(new ColorManager());
+			SwaggerScanner scanner = new SwaggerScanner(new ColorManager(), Activator.getDefault().getPreferenceStore());
 			Set<String> tokens = YAMLToken.VALID_TOKENS.keySet();
 			FastPartitioner partitioner = new FastPartitioner(scanner, tokens.toArray(new String[tokens.size()]));
 			document.setDocumentPartitioner(partitioner);
@@ -30,17 +30,6 @@ public class SwaggerDocumentProvider extends FileDocumentProvider {
 	@Override
 	protected IDocument createEmptyDocument() {
 		return new SwaggerDocument();
-	}
-
-	public static class SwaggerPartitionScanner extends YAMLScanner implements IPartitionTokenScanner {
-
-		public SwaggerPartitionScanner(ColorManager colorManager) {
-			super(colorManager);
-		}
-
-		@Override
-		public void setPartialRange(IDocument document, int offset, int length, String contentType,	int partitionOffset) {			
-		}
 	}
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -89,54 +89,54 @@ public class SwaggerEditor extends YEdit {
 		private final List<String> preferenceKeys = new ArrayList<>();
 		{
 			preferenceKeys.add(PreferenceConstants.COLOR_COMMENT);
-	        preferenceKeys.add(PreferenceConstants.BOLD_COMMENT);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_COMMENT);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_COMMENT);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_KEY);
-	        preferenceKeys.add(PreferenceConstants.BOLD_KEY);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_KEY);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_KEY);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_SCALAR);
-	        preferenceKeys.add(PreferenceConstants.BOLD_SCALAR);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_SCALAR);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_SCALAR);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_DEFAULT);
-	        preferenceKeys.add(PreferenceConstants.BOLD_DEFAULT);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_DEFAULT);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_DEFAULT);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_DOCUMENT);
-	        preferenceKeys.add(PreferenceConstants.BOLD_DOCUMENT);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_DOCUMENT);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_DOCUMENT);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_ANCHOR);
-	        preferenceKeys.add(PreferenceConstants.BOLD_ANCHOR);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_ANCHOR);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_ANCHOR);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_ALIAS);
-	        preferenceKeys.add(PreferenceConstants.BOLD_ALIAS);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_ALIAS);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_ALIAS);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_TAG_PROPERTY);
-	        preferenceKeys.add(PreferenceConstants.BOLD_TAG_PROPERTY);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_TAG_PROPERTY);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_TAG_PROPERTY);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_INDICATOR_CHARACTER);
-	        preferenceKeys.add(PreferenceConstants.BOLD_INDICATOR_CHARACTER);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_INDICATOR_CHARACTER);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_INDICATOR_CHARACTER);
-	        
-	        preferenceKeys.add(PreferenceConstants.COLOR_CONSTANT);
-	        preferenceKeys.add(PreferenceConstants.BOLD_CONSTANT);
-	        preferenceKeys.add(PreferenceConstants.ITALIC_CONSTANT);
-	        preferenceKeys.add(PreferenceConstants.UNDERLINE_CONSTANT);
+			preferenceKeys.add(PreferenceConstants.BOLD_COMMENT);
+			preferenceKeys.add(PreferenceConstants.ITALIC_COMMENT);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_COMMENT);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_KEY);
+			preferenceKeys.add(PreferenceConstants.BOLD_KEY);
+			preferenceKeys.add(PreferenceConstants.ITALIC_KEY);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_KEY);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_SCALAR);
+			preferenceKeys.add(PreferenceConstants.BOLD_SCALAR);
+			preferenceKeys.add(PreferenceConstants.ITALIC_SCALAR);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_SCALAR);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_DEFAULT);
+			preferenceKeys.add(PreferenceConstants.BOLD_DEFAULT);
+			preferenceKeys.add(PreferenceConstants.ITALIC_DEFAULT);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_DEFAULT);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_DOCUMENT);
+			preferenceKeys.add(PreferenceConstants.BOLD_DOCUMENT);
+			preferenceKeys.add(PreferenceConstants.ITALIC_DOCUMENT);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_DOCUMENT);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_ANCHOR);
+			preferenceKeys.add(PreferenceConstants.BOLD_ANCHOR);
+			preferenceKeys.add(PreferenceConstants.ITALIC_ANCHOR);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_ANCHOR);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_ALIAS);
+			preferenceKeys.add(PreferenceConstants.BOLD_ALIAS);
+			preferenceKeys.add(PreferenceConstants.ITALIC_ALIAS);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_ALIAS);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_TAG_PROPERTY);
+			preferenceKeys.add(PreferenceConstants.BOLD_TAG_PROPERTY);
+			preferenceKeys.add(PreferenceConstants.ITALIC_TAG_PROPERTY);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_TAG_PROPERTY);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_INDICATOR_CHARACTER);
+			preferenceKeys.add(PreferenceConstants.BOLD_INDICATOR_CHARACTER);
+			preferenceKeys.add(PreferenceConstants.ITALIC_INDICATOR_CHARACTER);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_INDICATOR_CHARACTER);
+
+			preferenceKeys.add(PreferenceConstants.COLOR_CONSTANT);
+			preferenceKeys.add(PreferenceConstants.BOLD_CONSTANT);
+			preferenceKeys.add(PreferenceConstants.ITALIC_CONSTANT);
+			preferenceKeys.add(PreferenceConstants.UNDERLINE_CONSTANT);
 		}
 
 		@Override
@@ -145,8 +145,8 @@ public class SwaggerEditor extends YEdit {
 				if(getSourceViewer() instanceof SourceViewer){
 					((SourceViewer) getSourceViewer()).unconfigure();
 					initializeEditor();
-		            getSourceViewer().configure(sourceViewerConfiguration);
-		        }
+					getSourceViewer().configure(sourceViewerConfiguration);
+				}
 			}
 		}
 	};

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerScanner.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerScanner.java
@@ -1,0 +1,175 @@
+package com.reprezen.swagedit.editor;
+
+import java.util.ArrayList;
+
+import org.dadacoalition.yedit.editor.ColorManager;
+import org.dadacoalition.yedit.editor.scanner.AnchorWordDetector;
+import org.dadacoalition.yedit.editor.scanner.DocumentStartAndEndRule;
+import org.dadacoalition.yedit.editor.scanner.DoubleQuotedKeyRule;
+import org.dadacoalition.yedit.editor.scanner.IndicatorCharacterRule;
+import org.dadacoalition.yedit.editor.scanner.KeyRule;
+import org.dadacoalition.yedit.editor.scanner.PredefinedValueRule;
+import org.dadacoalition.yedit.editor.scanner.ScalarRule;
+import org.dadacoalition.yedit.editor.scanner.SingleQuotedKeyRule;
+import org.dadacoalition.yedit.editor.scanner.TagWordDetector;
+import org.dadacoalition.yedit.editor.scanner.WhitespaceRule;
+import org.dadacoalition.yedit.editor.scanner.YAMLScanner;
+import org.dadacoalition.yedit.editor.scanner.YAMLToken;
+import org.dadacoalition.yedit.preferences.PreferenceConstants;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.TextAttribute;
+import org.eclipse.jface.text.rules.EndOfLineRule;
+import org.eclipse.jface.text.rules.IPartitionTokenScanner;
+import org.eclipse.jface.text.rules.IRule;
+import org.eclipse.jface.text.rules.IToken;
+import org.eclipse.jface.text.rules.MultiLineRule;
+import org.eclipse.jface.text.rules.WordPatternRule;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.graphics.RGB;
+
+/*
+ * Identical implementation of a BufferedRuleBasedScanner than YAMLScanner but makes 
+ * use of SwagEdit PreferenceStore to set SwagEdit colors instead of YEdit colors.
+ * 
+ * This implementation is necessary due to the lack of possibility to override YAMLScanner
+ * usage of a preference store.
+ */
+public class SwaggerScanner extends YAMLScanner implements IPartitionTokenScanner {
+
+	private ColorManager colorManager;
+	private IPreferenceStore store;
+
+	public SwaggerScanner(ColorManager colorManager, IPreferenceStore store) {
+		super(colorManager);
+
+		this.colorManager = colorManager;
+		this.store = store;
+		init();
+	}
+
+	protected void init() {
+		TextAttribute keyAttr = tokenAttribute( 
+				PreferenceConstants.COLOR_KEY, 
+				PreferenceConstants.BOLD_KEY,
+				PreferenceConstants.ITALIC_KEY, 
+				PreferenceConstants.UNDERLINE_KEY);
+
+		IToken keyToken = new YAMLToken(keyAttr, YAMLToken.KEY);
+
+		TextAttribute scalarAttr = tokenAttribute( 
+				PreferenceConstants.COLOR_SCALAR,
+				PreferenceConstants.BOLD_SCALAR, 
+				PreferenceConstants.ITALIC_SCALAR,
+				PreferenceConstants.UNDERLINE_SCALAR);
+		IToken scalarToken = new YAMLToken(scalarAttr, YAMLToken.SCALAR);
+
+		TextAttribute commentAttr = tokenAttribute( 
+				PreferenceConstants.COLOR_COMMENT,
+				PreferenceConstants.BOLD_COMMENT, 
+				PreferenceConstants.ITALIC_COMMENT,
+				PreferenceConstants.UNDERLINE_COMMENT);
+		IToken commentToken = new YAMLToken(commentAttr, YAMLToken.COMMENT);
+
+		TextAttribute documentAttr = tokenAttribute( 
+				PreferenceConstants.COLOR_DOCUMENT,
+				PreferenceConstants.BOLD_DOCUMENT, 
+				PreferenceConstants.ITALIC_DOCUMENT,
+				PreferenceConstants.UNDERLINE_DOCUMENT);
+
+		IToken documentStartToken = new YAMLToken(documentAttr, YAMLToken.DOCUMENT_START);
+		IToken documentEndToken = new YAMLToken(documentAttr, YAMLToken.DOCUMENT_END);
+
+		TextAttribute anchorAttr = tokenAttribute( 
+				PreferenceConstants.COLOR_ANCHOR,
+				PreferenceConstants.BOLD_ANCHOR, 
+				PreferenceConstants.ITALIC_ANCHOR,
+				PreferenceConstants.UNDERLINE_ANCHOR);
+		IToken anchorToken = new YAMLToken(anchorAttr, YAMLToken.ANCHOR);
+
+		TextAttribute aliasAttr = tokenAttribute( 
+				PreferenceConstants.COLOR_ALIAS, 
+				PreferenceConstants.BOLD_ALIAS,
+				PreferenceConstants.ITALIC_ALIAS, 
+				PreferenceConstants.UNDERLINE_ALIAS);
+		IToken aliasToken = new YAMLToken(aliasAttr, YAMLToken.ALIAS);
+
+		IToken indicatorCharToken = new YAMLToken(new TextAttribute(null), YAMLToken.INDICATOR_CHARACTER);
+
+		TextAttribute tagAttr = tokenAttribute( 
+				PreferenceConstants.COLOR_TAG_PROPERTY,
+				PreferenceConstants.BOLD_TAG_PROPERTY, 
+				PreferenceConstants.ITALIC_TAG_PROPERTY,
+				PreferenceConstants.UNDERLINE_TAG_PROPERTY);
+		IToken tagPropToken = new YAMLToken(tagAttr, YAMLToken.TAG_PROPERTY);
+
+		TextAttribute constantAttr = tokenAttribute( 
+				PreferenceConstants.COLOR_CONSTANT,
+				PreferenceConstants.BOLD_CONSTANT, 
+				PreferenceConstants.ITALIC_CONSTANT,
+				PreferenceConstants.UNDERLINE_CONSTANT);
+		IToken predefinedValToken = new YAMLToken(constantAttr, YAMLToken.CONSTANT);
+
+		IToken whitespaceToken = new YAMLToken(new TextAttribute(null), YAMLToken.WHITESPACE);
+
+		IToken directiveToken = new YAMLToken(new TextAttribute(null), YAMLToken.DIRECTIVE);
+
+		ArrayList<IRule> rules = new ArrayList<IRule>();
+
+		rules.add(new KeyRule(keyToken));
+		rules.add(new SingleQuotedKeyRule(keyToken));
+		rules.add(new DoubleQuotedKeyRule(keyToken));
+		rules.add(new MultiLineRule("\"", "\"", scalarToken, '\\'));
+		rules.add(new MultiLineRule("'", "'", scalarToken));
+		rules.add(new EndOfLineRule("#", commentToken));
+		rules.add(new EndOfLineRule("%TAG", directiveToken));
+		rules.add(new EndOfLineRule("%YAML", directiveToken));
+		rules.add(new DocumentStartAndEndRule("---", documentStartToken));
+		rules.add(new DocumentStartAndEndRule("...", documentEndToken));
+		rules.add(new IndicatorCharacterRule(indicatorCharToken));
+		rules.add(new WhitespaceRule(whitespaceToken));
+		rules.add(new WordPatternRule(new AnchorWordDetector(), "&", "", anchorToken));
+		rules.add(new WordPatternRule(new AnchorWordDetector(), "*", "", aliasToken));
+		rules.add(new WordPatternRule(new TagWordDetector(), "!", "", tagPropToken));
+
+		rules.add(new PredefinedValueRule(predefinedValToken));
+
+		rules.add(new ScalarRule(scalarToken));
+
+		IRule[] rulesArray = new IRule[rules.size()];
+		rules.toArray(rulesArray);
+		setRules(rulesArray);
+		setDefaultReturnToken(scalarToken);
+
+	}
+
+	private TextAttribute tokenAttribute(String colorPrefs, String boldPrefs, String italicPrefs, String underlinePrefs) {
+		int style = SWT.NORMAL;
+
+		boolean isBold = store.getBoolean(boldPrefs);
+		if (isBold) {
+			style = style | SWT.BOLD;
+		}
+
+		boolean isItalic = store.getBoolean(italicPrefs);
+		if (isItalic) {
+			style = style | SWT.ITALIC;
+		}
+
+		boolean isUnderline = store.getBoolean(underlinePrefs);
+		if (isUnderline) {
+			style = style | TextAttribute.UNDERLINE;
+		}
+
+		RGB color = PreferenceConverter.getColor(store, colorPrefs);
+		TextAttribute attr = new TextAttribute(colorManager.getColor(color), null, style);
+		return attr;
+	}
+
+	@Override
+	public void setPartialRange(IDocument document, int offset, int length, String contentType, int partitionOffset) {
+		// TODO
+	}
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerSourceViewerConfiguration.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerSourceViewerConfiguration.java
@@ -1,6 +1,7 @@
 package com.reprezen.swagedit.editor;
 
 import org.dadacoalition.yedit.editor.YEditSourceViewerConfiguration;
+import org.dadacoalition.yedit.editor.scanner.YAMLScanner;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
 import org.eclipse.jface.text.contentassist.IContentAssistant;
@@ -8,11 +9,13 @@ import org.eclipse.jface.text.reconciler.IReconciler;
 import org.eclipse.jface.text.reconciler.MonoReconciler;
 import org.eclipse.jface.text.source.ISourceViewer;
 
+import com.reprezen.swagedit.Activator;
 import com.reprezen.swagedit.assist.SwaggerContentAssistProcessor;
 
 public class SwaggerSourceViewerConfiguration extends YEditSourceViewerConfiguration {
 
 	private SwaggerEditor editor;
+	private YAMLScanner scanner;
 
 	public SwaggerSourceViewerConfiguration() {
 		super();
@@ -32,6 +35,14 @@ public class SwaggerSourceViewerConfiguration extends YEditSourceViewerConfigura
 		ca.setShowEmptyList(true);
 
 		return ca;
+	}
+
+	@Override
+	protected YAMLScanner getScanner() {
+		if (scanner == null) {
+			scanner = new SwaggerScanner(colorManager, Activator.getDefault().getPreferenceStore());
+		}
+		return scanner;
 	}
 
 	@Override

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerColorPreferences.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerColorPreferences.java
@@ -1,12 +1,19 @@
 package com.reprezen.swagedit.preferences;
 
-import org.dadacoalition.yedit.Activator;
 import org.dadacoalition.yedit.preferences.ColorPreferences;
 
+import com.reprezen.swagedit.Activator;
+
+/*
+ * This implementation of preference page overrides the YEdit implementation but 
+ * uses it's own preference store.
+ * 
+ */
 public class SwaggerColorPreferences extends ColorPreferences {
 
 	public SwaggerColorPreferences() {
 		super();
+
         setPreferenceStore(Activator.getDefault().getPreferenceStore());
         setDescription("Swagger Color Preferences for syntax highlighting");
 	}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerPreferenceInitializer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerPreferenceInitializer.java
@@ -1,0 +1,77 @@
+package com.reprezen.swagedit.preferences;
+
+import org.dadacoalition.yedit.preferences.PreferenceConstants;
+import org.eclipse.core.runtime.preferences.AbstractPreferenceInitializer;
+import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.preference.PreferenceConverter;
+import org.eclipse.swt.graphics.RGB;
+
+import com.reprezen.swagedit.Activator;
+
+/*
+ * SwagEdit default preference values.
+ * 
+ */
+public class SwaggerPreferenceInitializer extends AbstractPreferenceInitializer {
+
+	@Override
+	public void initializeDefaultPreferences() {
+		IPreferenceStore store = Activator.getDefault().getPreferenceStore();
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_DEFAULT, new RGB(0, 0, 0));
+		store.setDefault(PreferenceConstants.BOLD_DEFAULT, false);
+		store.setDefault(PreferenceConstants.ITALIC_DEFAULT, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_DEFAULT, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_DEFAULT, new RGB(0, 0, 0));
+		store.setDefault(PreferenceConstants.BOLD_DEFAULT, false);
+		store.setDefault(PreferenceConstants.ITALIC_DEFAULT, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_DEFAULT, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_COMMENT, new RGB(57, 127, 98));
+		store.setDefault(PreferenceConstants.BOLD_COMMENT, false);
+		store.setDefault(PreferenceConstants.ITALIC_COMMENT, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_COMMENT, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_KEY, new RGB(130, 0, 82));
+		store.setDefault(PreferenceConstants.BOLD_KEY, true);
+		store.setDefault(PreferenceConstants.ITALIC_KEY, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_KEY, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_DOCUMENT, new RGB(0, 0, 0));
+		store.setDefault(PreferenceConstants.BOLD_DOCUMENT, false);
+		store.setDefault(PreferenceConstants.ITALIC_DOCUMENT, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_DOCUMENT, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_SCALAR, new RGB(0, 0, 0));
+		store.setDefault(PreferenceConstants.BOLD_SCALAR, false);
+		store.setDefault(PreferenceConstants.ITALIC_SCALAR, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_SCALAR, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_ANCHOR, new RGB(175, 0, 255));
+		store.setDefault(PreferenceConstants.BOLD_ANCHOR, false);
+		store.setDefault(PreferenceConstants.ITALIC_ANCHOR, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_ANCHOR, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_ALIAS, new RGB(175, 0, 255));
+		store.setDefault(PreferenceConstants.BOLD_ALIAS, false);
+		store.setDefault(PreferenceConstants.ITALIC_ALIAS, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_ALIAS, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_TAG_PROPERTY, new RGB(175, 0, 255));
+		store.setDefault(PreferenceConstants.BOLD_TAG_PROPERTY, false);
+		store.setDefault(PreferenceConstants.ITALIC_TAG_PROPERTY, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_TAG_PROPERTY, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_INDICATOR_CHARACTER, new RGB(0, 0, 0));
+		store.setDefault(PreferenceConstants.BOLD_INDICATOR_CHARACTER, false);
+		store.setDefault(PreferenceConstants.ITALIC_INDICATOR_CHARACTER, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_INDICATOR_CHARACTER, false);
+
+		PreferenceConverter.setDefault(store, PreferenceConstants.COLOR_CONSTANT, new RGB(45, 32, 244));
+		store.setDefault(PreferenceConstants.BOLD_CONSTANT, true);
+		store.setDefault(PreferenceConstants.ITALIC_CONSTANT, false);
+		store.setDefault(PreferenceConstants.UNDERLINE_CONSTANT, false);
+	}
+
+}


### PR DESCRIPTION
This is the pull request to add a default theme for SwagEdit, see #44 

It involves some changes since to have default colors for SwagEdit, we need to use a different preference store than the one from YEdit.

Also since we want eclipse-color-theme to work with SwagEdit, and we use different preferences from YEdit, we need to provide a SwagEdit preference mapping file for eclipse-color-theme (this is the new xml file in folder resources). This also includes a new dependency to eclipse-color-theme, but I marked it as optional. Without that mapping file, the colors of the SwagEdit editor would not be changed if the user chooses a new color theme, only the background would change.
