### PR TITLE
[#60] Provide better error messages for `oneOf` schema validation failures

### DIFF
--- a/com.reprezen.swagedit.tests/resources/error-1.json
+++ b/com.reprezen.swagedit.tests/resources/error-1.json
@@ -1,0 +1,24 @@
+{
+  "level": "error",
+  "schema": {
+    "loadingURI": "#",
+    "pointer": ""
+  },
+  "instance": {
+    "pointer": ""
+  },
+  "domain": "validation",
+  "keyword": "additionalProperties",
+  "message": "object instance has properties which are not allowed by the schema: [\"domain\",\"instance\",\"keyword\",\"level\",\"matched\",\"message\",\"nrSchemas\",\"reports\",\"schema\"]",
+  "unwanted": [
+    "domain",
+    "instance",
+    "keyword",
+    "level",
+    "matched",
+    "message",
+    "nrSchemas",
+    "reports",
+    "schema"
+  ]
+}

--- a/com.reprezen.swagedit.tests/resources/error-2.json
+++ b/com.reprezen.swagedit.tests/resources/error-2.json
@@ -1,0 +1,215 @@
+{
+  "level": "error",
+  "schema": {
+    "loadingURI": "http://swagger.io/v2/schema.json#",
+    "pointer": "/definitions/parametersList/items"
+  },
+  "instance": {
+    "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0"
+  },
+  "domain": "validation",
+  "keyword": "oneOf",
+  "message": "instance failed to match exactly one schema (matched 0 out of 2)",
+  "matched": 0,
+  "nrSchemas": 2,
+  "reports": {
+    "/definitions/parametersList/items/oneOf/0": [
+      {
+        "level": "error",
+        "schema": {
+          "loadingURI": "http://swagger.io/v2/schema.json#",
+          "pointer": "/definitions/parameter"
+        },
+        "instance": {
+          "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0"
+        },
+        "domain": "validation",
+        "keyword": "oneOf",
+        "message": "instance failed to match exactly one schema (matched 0 out of 2)",
+        "matched": 0,
+        "nrSchemas": 2,
+        "reports": {
+          "/definitions/parameter/oneOf/0": [
+            {
+              "level": "error",
+              "schema": {
+                "loadingURI": "http://swagger.io/v2/schema.json#",
+                "pointer": "/definitions/bodyParameter"
+              },
+              "instance": {
+                "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0"
+              },
+              "domain": "validation",
+              "keyword": "required",
+              "message": "object has missing required properties ([\"schema\"])",
+              "required": [
+                "in",
+                "name",
+                "schema"
+              ],
+              "missing": [
+                "schema"
+              ]
+            }
+          ],
+          "/definitions/parameter/oneOf/1": [
+            {
+              "level": "error",
+              "schema": {
+                "loadingURI": "http://swagger.io/v2/schema.json#",
+                "pointer": "/definitions/nonBodyParameter"
+              },
+              "instance": {
+                "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0"
+              },
+              "domain": "validation",
+              "keyword": "oneOf",
+              "message": "instance failed to match exactly one schema (matched 0 out of 4)",
+              "matched": 0,
+              "nrSchemas": 4,
+              "reports": {
+                "/definitions/nonBodyParameter/oneOf/0": [
+                  {
+                    "level": "error",
+                    "schema": {
+                      "loadingURI": "http://swagger.io/v2/schema.json#",
+                      "pointer": "/definitions/headerParameterSubSchema/properties/in"
+                    },
+                    "instance": {
+                      "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0/in"
+                    },
+                    "domain": "validation",
+                    "keyword": "enum",
+                    "message": "instance value (\"body\") not found in enum (possible values: [\"header\"])",
+                    "value": "body",
+                    "enum": [
+                      "header"
+                    ]
+                  }
+                ],
+                "/definitions/nonBodyParameter/oneOf/1": [
+                  {
+                    "level": "error",
+                    "schema": {
+                      "loadingURI": "http://swagger.io/v2/schema.json#",
+                      "pointer": "/definitions/formDataParameterSubSchema/properties/in"
+                    },
+                    "instance": {
+                      "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0/in"
+                    },
+                    "domain": "validation",
+                    "keyword": "enum",
+                    "message": "instance value (\"body\") not found in enum (possible values: [\"formData\"])",
+                    "value": "body",
+                    "enum": [
+                      "formData"
+                    ]
+                  }
+                ],
+                "/definitions/nonBodyParameter/oneOf/2": [
+                  {
+                    "level": "error",
+                    "schema": {
+                      "loadingURI": "http://swagger.io/v2/schema.json#",
+                      "pointer": "/definitions/queryParameterSubSchema/properties/in"
+                    },
+                    "instance": {
+                      "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0/in"
+                    },
+                    "domain": "validation",
+                    "keyword": "enum",
+                    "message": "instance value (\"body\") not found in enum (possible values: [\"query\"])",
+                    "value": "body",
+                    "enum": [
+                      "query"
+                    ]
+                  }
+                ],
+                "/definitions/nonBodyParameter/oneOf/3": [
+                  {
+                    "level": "error",
+                    "schema": {
+                      "loadingURI": "http://swagger.io/v2/schema.json#",
+                      "pointer": "/definitions/pathParameterSubSchema/properties/in"
+                    },
+                    "instance": {
+                      "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0/in"
+                    },
+                    "domain": "validation",
+                    "keyword": "enum",
+                    "message": "instance value (\"body\") not found in enum (possible values: [\"path\"])",
+                    "value": "body",
+                    "enum": [
+                      "path"
+                    ]
+                  }
+                ]
+              }
+            },
+            {
+              "level": "error",
+              "schema": {
+                "loadingURI": "http://swagger.io/v2/schema.json#",
+                "pointer": "/definitions/nonBodyParameter"
+              },
+              "instance": {
+                "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0"
+              },
+              "domain": "validation",
+              "keyword": "required",
+              "message": "object has missing required properties ([\"type\"])",
+              "required": [
+                "in",
+                "name",
+                "type"
+              ],
+              "missing": [
+                "type"
+              ]
+            }
+          ]
+        }
+      }
+    ],
+    "/definitions/parametersList/items/oneOf/1": [
+      {
+        "level": "error",
+        "schema": {
+          "loadingURI": "http://swagger.io/v2/schema.json#",
+          "pointer": "/definitions/jsonReference"
+        },
+        "instance": {
+          "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0"
+        },
+        "domain": "validation",
+        "keyword": "additionalProperties",
+        "message": "object instance has properties which are not allowed by the schema: [\"description\",\"in\",\"name\",\"required\"]",
+        "unwanted": [
+          "description",
+          "in",
+          "name",
+          "required"
+        ]
+      },
+      {
+        "level": "error",
+        "schema": {
+          "loadingURI": "http://swagger.io/v2/schema.json#",
+          "pointer": "/definitions/jsonReference"
+        },
+        "instance": {
+          "pointer": "/paths/~1taxFilings~1{id}/put/parameters/0"
+        },
+        "domain": "validation",
+        "keyword": "required",
+        "message": "object has missing required properties ([\"$ref\"])",
+        "required": [
+          "$ref"
+        ],
+        "missing": [
+          "$ref"
+        ]
+      }
+    ]
+  }
+}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/TestSuite.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/TestSuite.java
@@ -4,6 +4,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
+import com.reprezen.swagedit.validation.ErrorProcessorTest;
+
 @RunWith(Suite.class)
 @SuiteClasses({
 	SwaggerContentAssistProcessorTest.class,
@@ -11,6 +13,7 @@ import org.junit.runners.Suite.SuiteClasses;
 	SwaggerProposalProviderTest.class,
 	SwaggerSchemaTest.class,
 	ValidationMessageTest.class,
-	ValidatorTest.class
+	ValidatorTest.class,
+	ErrorProcessorTest.class
 })
 public class TestSuite {}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/ValidationMessageTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/ValidationMessageTest.xtend
@@ -117,11 +117,7 @@ class ValidationMessageTest {
 		document.set(content)
 		val errors = validator.validate(document)
 
-		assertThat(errors.map[message], hasItems(
-			"value of type integer is not allowed, value should be of type string",
-			"object has properties \"description\" which are not allowed",
-			"object has missing required properties \"$ref\""
-		))
+		assertEquals(1, errors.size)
 	}
 
 	@Test

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/ValidatorTest.xtend
@@ -170,7 +170,7 @@ class ValidatorTest {
 		document.set(content)
 		val errors = validator.validate(document)
 
-		assertEquals(5, errors.size())
+		assertEquals(1, errors.size())
 
 		errors.forEach[
 			assertTrue(it.line == 10 || it.line == 11)

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ErrorProcessorTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ErrorProcessorTest.java
@@ -1,0 +1,45 @@
+package com.reprezen.swagedit.validation;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Paths;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.yaml.snakeyaml.nodes.Node;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ErrorProcessorTest {
+
+	private ErrorProcessor processor;
+	private ObjectMapper mapper = new ObjectMapper();
+
+	@Before
+	public void setUp() {
+		Node document = null;
+		processor = new ErrorProcessor(document);
+	}
+
+	@Test
+	public void testProcessNode_WithSingleError() throws Exception {
+		JsonNode fixture = mapper.readTree(Paths.get("resources", "error-1.json").toFile());
+		Set<SwaggerError> errors = processor.processMessageNode(fixture);
+
+		assertEquals(1, errors.size());
+		assertTrue(errors.iterator().next() instanceof SwaggerError);
+	}
+
+	@Test
+	public void testProcessNode_WithOneOfError() throws Exception {
+		JsonNode fixture = mapper.readTree(Paths.get("resources", "error-2.json").toFile());
+		Set<SwaggerError> errors = processor.processMessageNode(fixture);
+
+		assertEquals(1, errors.size());	
+		assertTrue(errors.iterator().next() instanceof SwaggerError.MultipleSwaggerError);
+	}
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -303,7 +303,7 @@ public class SwaggerEditor extends YEdit {
 
 	protected void validateYaml(IFile file, SwaggerDocument document) {
 		if (document.getYamlError() instanceof YAMLException) {
-			addMarker(SwaggerError.create((YAMLException) document.getYamlError()), file, document);
+			addMarker(new SwaggerError((YAMLException) document.getYamlError()), file, document);
 		}
 	}
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ErrorProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ErrorProcessor.java
@@ -1,0 +1,188 @@
+package com.reprezen.swagedit.validation;
+
+import static com.reprezen.swagedit.validation.ValidationUtil.getLine;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.eclipse.core.resources.IMarker;
+import org.yaml.snakeyaml.nodes.Node;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.github.fge.jsonschema.core.report.ProcessingMessage;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.google.common.base.Joiner;
+import com.reprezen.swagedit.Messages;
+import com.reprezen.swagedit.validation.SwaggerError.MultipleSwaggerError;
+
+/**
+ * Creates {@link SwaggerError} by processing validation reports generated 
+ * by the json schema validator.
+ */
+public class ErrorProcessor {
+
+	private final Node document;
+
+	public ErrorProcessor(Node document) {
+		this.document = document;
+	}
+
+	/**
+	 * Returns set of {@link SwaggerError} created from a validation report.
+	 * 
+	 * @param report to process
+	 * @return set of validation errors
+	 */
+	public Set<SwaggerError> processReport(ProcessingReport report) {
+		final Set<SwaggerError> errors = new HashSet<>();
+		if (report != null) {
+			for (Iterator<ProcessingMessage> it = report.iterator(); it.hasNext();) {
+				errors.addAll(processMessage(it.next()));
+			}
+		}
+		return errors;
+	}
+
+	/**
+	 * Returns set of {@link SwaggerError} created from a validation message.
+	 * 
+	 * @param message to process
+	 * @return set of validation errors
+	 */
+	public Set<SwaggerError> processMessage(ProcessingMessage message) {
+		return fromNode(message.asJson(), 0);
+	}
+
+	public Set<SwaggerError> processMessageNode(JsonNode value) {
+		return fromNode(value, 0);
+	}
+
+	private Set<SwaggerError> fromNode(JsonNode error, int indent) {
+		final Set<SwaggerError> errors = new HashSet<>();
+
+		if (error.isArray()) {
+			for (JsonNode el: error) {
+				if (isMultiple(el)) {
+					errors.add(createMultiple(el, indent));
+				} else {
+					errors.add(createUnique(el, indent));
+				}
+			}
+		} else if (error.isObject()) {
+			if (isMultiple(error)) {
+				errors.add(createMultiple(error, indent));
+			} else {
+				errors.add(createUnique(error, indent));
+			}
+		}
+
+		return errors;
+	}
+
+	/**
+	 * Returns true if the error matches more than one schema.
+	 * 
+	 * @param error
+	 * @return true if validation concerns more than one schema.
+	 */
+	private boolean isMultiple(JsonNode error) {
+		return error.has("nrSchemas") && error.get("nrSchemas").asInt() > 1;
+	}
+
+	private SwaggerError createUnique(JsonNode error, int indent) {
+		final SwaggerError schemaError = new SwaggerError(
+				getLine(error, document), 
+				getLevel(error), 
+				rewriteError(error));
+		schemaError.indent = indent;
+
+		return schemaError;
+	}
+
+	private SwaggerError createMultiple(JsonNode error, int indent) {
+		final MultipleSwaggerError schemaError = new MultipleSwaggerError(
+				getLine(error, document), 
+				getLevel(error));
+		schemaError.indent = indent;
+
+		final JsonNode reports = error.get("reports");
+		for (Iterator<Entry<String, JsonNode>> it = reports.fields(); it.hasNext();) {
+			Entry<String, JsonNode> next = it.next();
+			schemaError.put(next.getKey(), fromNode(next.getValue(), indent + 1));
+		}
+
+		return schemaError;
+	}
+
+	protected String rewriteError(JsonNode error) {
+		if (error == null || !error.has("keyword")) {
+			return "";
+		}
+
+		switch (error.get("keyword").asText()) {
+			case "type":
+				return rewriteTypeError(error);
+			case "enum":
+				return rewriteEnumError(error);
+			case "additionalProperties":
+				return rewriteAdditionalProperties(error);
+			case "required":
+				return rewriteRequiredProperties(error);
+			default:
+				return error.get("message").asText();
+		}
+	}
+
+	protected String rewriteRequiredProperties(JsonNode error) {
+		JsonNode missing = error.get("missing");
+
+		return String.format(Messages.error_required_properties, Joiner.on(", ").join(missing));
+	}
+
+	protected String rewriteAdditionalProperties(JsonNode error) {
+		final JsonNode unwanted = error.get("unwanted");
+
+		return String.format(Messages.error_additional_properties_not_allowed, Joiner.on(", ").join(unwanted));
+	}
+
+	protected String rewriteTypeError(JsonNode error) {
+		final JsonNode found = error.get("found");
+		final JsonNode expected = error.get("expected");
+
+		String expect;
+		if (expected.isArray()) {
+			expect = expected.get(0).asText();
+		} else {
+			expect = expected.asText();
+		}
+
+		return String.format(Messages.error_typeNoMatch, found.asText(), expect);
+	}
+
+	protected String rewriteEnumError(JsonNode error) {
+		final JsonNode value = error.get("value");
+		final JsonNode enums = error.get("enum");
+		final String enumString = Joiner.on(", ").join(enums);
+
+		return String.format(Messages.error_notInEnum, value.asText(), enumString);
+	}
+
+	protected int getLevel(JsonNode message) {
+		if (message == null || !message.has("level")) {
+			return IMarker.SEVERITY_INFO;
+		}
+
+		switch (message.get("level").asText()) {
+			case "error":
+			case "fatal":
+				return IMarker.SEVERITY_ERROR;
+			case "warning":
+				return IMarker.SEVERITY_WARNING;
+			default:
+				return IMarker.SEVERITY_INFO;
+		}
+	}
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
@@ -1,133 +1,50 @@
 package com.reprezen.swagedit.validation;
 
-import java.util.Objects;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.core.resources.IMarker;
 import org.yaml.snakeyaml.error.MarkedYAMLException;
 import org.yaml.snakeyaml.error.YAMLException;
 
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.dataformat.yaml.snakeyaml.scanner.ScannerException;
-import com.google.common.base.Joiner;
-import com.reprezen.swagedit.Messages;
+import com.google.common.base.Strings;
 
 public class SwaggerError {
 
-	private final int level;
-	private final String message;
-	private final int line;
+	public String schema;
+	public String schemaPointer;
+	public String instancePointer;
+	public String keyword;
+	public String message;
 
-	public SwaggerError(int level, String message) {
-		this(level, message, 1);
-	}
+	public int level;
+	public int line;
+	public int indent = 0;
 
-	public SwaggerError(int level, String message, int line) {
+	public SwaggerError(int line, int level, String message) {
+		this.line = line;
 		this.level = level;
 		this.message = message;
-		this.line = line;
 	}
 
-	public static SwaggerError create(JsonMappingException exception) {
-		int line = 1;
-		if (exception.getLocation() != null) {
-			line = exception.getLocation().getLineNr();
-		}
-
-		return new SwaggerError(IMarker.SEVERITY_ERROR, exception.getMessage(), line);
+	public SwaggerError(int level, String message) {
+		this(1, level, message);
 	}
 
-	public static SwaggerError create(JsonNode error, int line) {
-		return new SwaggerError(getLevel(error), rewriteError(error), line);
-	}
+	public SwaggerError(YAMLException exception) {
+		this.level = IMarker.SEVERITY_ERROR;
+		this.message = exception.getMessage();
 
-	public static SwaggerError create(YAMLException error) {
-		if (error instanceof MarkedYAMLException) {
-			return new SwaggerError(IMarker.SEVERITY_ERROR, 
-					error.getMessage(),
-					((MarkedYAMLException) error).getProblemMark().getLine() + 1);
+		if (exception instanceof MarkedYAMLException) {
+			this.line = ((MarkedYAMLException) exception).getProblemMark().getLine() + 1;
 		} else {
-			return new SwaggerError(IMarker.SEVERITY_ERROR, error.getMessage(), 1);
+			this.line = 1;
 		}
 	}
 
-	public static SwaggerError create(com.fasterxml.jackson.dataformat.yaml.snakeyaml.parser.ParserException e) {
-		return new SwaggerError(IMarker.SEVERITY_ERROR, e.getMessage(), e.getProblemMark().getLine() + 1);
-	}
-
-	public static SwaggerError create(ScannerException e) {
-		return new SwaggerError(IMarker.SEVERITY_ERROR, e.getMessage(), e.getProblemMark().getLine() + 1);
-	}
-
-	private static String rewriteError(JsonNode error) {
-		if (error == null || !error.has("keyword")) {
-			return "";
-		}
-
-		switch (error.get("keyword").asText()) {
-		case "type":
-			return rewriteTypeError(error);
-		case "enum":
-			return rewriteEnumError(error);
-		case "additionalProperties":
-			return rewriteAdditionalProperties(error);
-		case "required":
-			return rewriteRequiredProperties(error);
-		default:
-			return error.get("message").asText();
-		}
-	}
-
-	private static String rewriteRequiredProperties(JsonNode error) {
-		JsonNode missing = error.get("missing");
-
-		return String.format(Messages.error_required_properties, Joiner.on(", ").join(missing));
-	}
-
-	private static String rewriteAdditionalProperties(JsonNode error) {
-		final JsonNode unwanted = error.get("unwanted");
-
-		return String.format(Messages.error_additional_properties_not_allowed, Joiner.on(", ").join(unwanted));
-	}
-
-	private static String rewriteTypeError(JsonNode error) {
-		final JsonNode found = error.get("found");
-		final JsonNode expected = error.get("expected");
-
-		String expect;
-		if (expected.isArray()) {
-			expect = expected.get(0).asText();
-		} else {
-			expect = expected.asText();
-		}
-
-		return String.format(Messages.error_typeNoMatch, found.asText(), expect);
-	}
-
-	private static String rewriteEnumError(JsonNode error) {
-		final JsonNode value = error.get("value");
-		final JsonNode enums = error.get("enum");
-		final String enumString = Joiner.on(", ").join(enums);
-
-		return String.format(Messages.error_notInEnum, value.asText(), enumString);
-	}
-
-	protected static int getLevel(JsonNode message) {
-		if (message == null || !message.has("level")) {
-			return IMarker.SEVERITY_INFO;
-		}
-
-		final String level = message.get("level").asText();
-
-		switch (level) {
-		case "error":
-		case "fatal":
-			return IMarker.SEVERITY_ERROR;
-		case "warning":
-			return IMarker.SEVERITY_WARNING;
-		default:
-			return IMarker.SEVERITY_INFO;
-		}
+	public String getMessage() {
+		return message;
 	}
 
 	public int getLevel() {
@@ -138,28 +55,64 @@ public class SwaggerError {
 		return line;
 	}
 
-	public String getMessage() {
+	String getMessage(boolean withIndent) {
+		if (withIndent) {
+			final StringBuilder builder = new StringBuilder();
+			builder.append(Strings.repeat("\t", indent));
+			builder.append(" - ");
+			builder.append(message);
+			builder.append("\n");
+
+			return builder.toString();
+		}
+		
 		return message;
 	}
 
-	@Override
-	public String toString() {
-		return "{ (level=" + getLevel() + ") " + getMessage() + " at line " + getLine() + " }";
-	}
+	public static class MultipleSwaggerError extends SwaggerError {
 
-	@Override
-	public boolean equals(Object obj) {
-		if (obj instanceof SwaggerError) {
-			return Objects.equals(level, ((SwaggerError) obj).level) &&
-					Objects.equals(line, ((SwaggerError) obj).line) &&
-					Objects.equals(message, ((SwaggerError) obj).message);
+		private final Map<String, Set<SwaggerError>> errors = new HashMap<>();
+
+		public MultipleSwaggerError(int line, int level) {
+			super(line, level, null);
 		}
 
-		return super.equals(obj);
+		public void put(String key, Set<SwaggerError> errors) {
+			this.errors.put(key, errors);
+		}
+
+		public Map<String, Set<SwaggerError>> getErrors() {
+			return errors;
+		}
+
+		@Override
+		String getMessage(boolean withIndent) {
+			return getMessage();
+		}
+
+		@Override
+		public String getMessage() {
+			final StringBuilder builder = new StringBuilder();
+			final String tabs = Strings.repeat("\t", indent);
+
+			builder.append(tabs);
+			builder.append("Failed to match exactly one schema:");
+			builder.append("\n");
+
+			for (String key: errors.keySet()) {
+				builder.append(tabs);
+				builder.append(" - ");
+				builder.append(key);
+				builder.append(":");
+				builder.append("\n");
+
+				for (SwaggerError e: errors.get(key)) {
+					builder.append(e.getMessage(true));
+				}
+			}
+
+			return builder.toString();
+		}
 	}
 
-	@Override
-	public int hashCode() {
-		return message.hashCode();
-	}
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ValidationUtil.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ValidationUtil.java
@@ -1,0 +1,98 @@
+package com.reprezen.swagedit.validation;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.yaml.snakeyaml.nodes.MappingNode;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class ValidationUtil {
+
+	/*
+	 * Returns the line for which an error message has been produced.
+	 *
+	 * The error message is a JSON object that contains the path to the invalid
+	 * node. The path is accessible via instance.pointer. The path is in the
+	 * forms: 
+	 *  - /{id} 
+	 *  - /{id}/~{nb} 
+	 *  - /{id}/~{id2}
+	 *
+	 * The line number is computed by after parsing the yaml content with the
+	 * yaml parser. This latter returns a tree of Node, each corresponding to a
+	 * yaml construct and including a position.
+	 *
+	 * The Node matching the path is found by the methods findNode().
+	 */
+	public static int getLine(JsonNode error, Node yamlTree) {
+		if (!error.has("instance") || !error.get("instance").has("pointer"))
+			return 1;
+
+		String path = error.get("instance").get("pointer").asText();
+
+		if (path == null || path.isEmpty())
+			return 1;
+
+		path = path.substring(1, path.length());
+		String[] strings = path.split("/");
+
+		if (yamlTree instanceof MappingNode) {
+			MappingNode mn = (MappingNode) yamlTree;
+
+			Node findNode = findNode(mn, Arrays.asList(strings));
+			if (findNode != null) {
+				return findNode.getStartMark().getLine() + 1;
+			}
+		}
+
+		return 1;
+	}
+
+	/*
+	 * Returns the yaml node that matches the given path.
+	 *
+	 * The path is given as a list of String. The Node matching the
+	 * path is found by traversing the children of the node pass as
+	 * first parameter.
+	 *
+	 */
+	private static Node findNode(MappingNode root, List<String> paths) {
+		if (paths.isEmpty())
+			return root;
+
+		String path = paths.get(0);
+		if (path.startsWith("/")) {
+			path = path.substring(1, path.length());
+		}
+
+		final List<String> next = paths.subList(1, paths.size());
+		// ~1 is use to escape /
+		if (path.contains("~1")) {
+			path = path.replaceAll("~1", "/");
+		}
+
+		for (NodeTuple child : root.getValue()) {
+			if (child.getKeyNode() instanceof ScalarNode) {
+				ScalarNode scalar = (ScalarNode) child.getKeyNode();
+
+				if (scalar.getValue().equals(path)) {
+					return findNode(child, next);
+				}
+			}
+		}
+
+		return root;
+	}
+
+	private static Node findNode(NodeTuple child, List<String> paths) {
+		if (child.getValueNode() instanceof MappingNode) {
+			return findNode((MappingNode) child.getValueNode(), paths);
+		}
+		return child.getKeyNode();
+	}
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
@@ -1,25 +1,16 @@
 package com.reprezen.swagedit.validation;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Set;
 
 import org.dadacoalition.yedit.YEditLog;
 import org.eclipse.core.resources.IMarker;
-import org.yaml.snakeyaml.nodes.MappingNode;
 import org.yaml.snakeyaml.nodes.Node;
-import org.yaml.snakeyaml.nodes.NodeTuple;
-import org.yaml.snakeyaml.nodes.ScalarNode;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.snakeyaml.parser.ParserException;
 import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.github.fge.jsonschema.core.report.ProcessingMessage;
 import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.reprezen.swagedit.editor.SwaggerDocument;
 import com.reprezen.swagedit.json.JsonSchemaManager;
@@ -55,150 +46,21 @@ public class Validator {
 		}
 
 		if (jsonContent == null) {
-			return Collections.singleton(
-					new SwaggerError(IMarker.SEVERITY_ERROR, "Unable to read content.  It may be invalid YAML"));
+			return Collections.singleton(new SwaggerError(IMarker.SEVERITY_ERROR, 
+					"Unable to read content. It may be invalid YAML"));
 		} else {
 			final Node yaml = document.getYaml();
-			ProcessingReport report = null;
+			final ErrorProcessor processor = new ErrorProcessor(yaml);
 
+			ProcessingReport report = null;
 			try {
 				report = schemaManager.getSwaggerSchema().getSchema().validate(jsonContent, true);
 			} catch (ProcessingException e) {
-				final ProcessingMessage pm = e.getProcessingMessage();
-				final int line = getLine(pm.asJson(), yaml);
-
-				return Collections.singleton(SwaggerError.create(pm.asJson(), line));
+				return processor.processMessage(e.getProcessingMessage());
 			}
 
-			return create(report, document.getYaml());
+			return processor.processReport(report);
 		}
-	}
-
-	private Set<SwaggerError> create(ProcessingReport report, Node yamlTree) {
-		final Set<SwaggerError> errors = new HashSet<>();
-		if (report != null) {
-			for (Iterator<ProcessingMessage> it = report.iterator(); it.hasNext();) {
-				final ProcessingMessage next = it.next();
-				final Set<JsonNode> reportNodes = collectReports(next.asJson());
-
-				for (JsonNode reportNode : reportNodes) {
-					errors.add( SwaggerError.create(reportNode, getLine(reportNode, yamlTree)) );
-				}
-			}
-		}
-
-		return errors;
-	}
-
-	private Set<JsonNode> collectReports(JsonNode message) {
-		final Set<JsonNode> allReports = new HashSet<>();
-
-		if (message.has("reports")) {
-			final JsonNode reports = message.get("reports");
-			allReports.add(((ObjectNode) message).without("reports"));
-
-			for (Iterator<String> it = reports.fieldNames(); it.hasNext();) {
-				String key = it.next();
-				JsonNode value = reports.get(key);
-
-				if (value.isArray()) {
-					for (JsonNode current : value) {
-						allReports.addAll(collectReports(current));
-						allReports.add(((ObjectNode) current).without("reports"));
-					}
-				} else if (value.isObject()) {
-					allReports.addAll(collectReports(value));
-					allReports.add(((ObjectNode) value).without("reports"));
-				}
-			}
-		} else {
-			allReports.add(message);
-		}
-
-		return allReports;
-	}
-
-	/*
-	 * Returns the line for which an error message has been produced.
-	 *
-	 * The error message is a JSON object that contains the path to the invalid
-	 * node. The path is accessible via instance.pointer. The path is in the
-	 * forms: 
-	 *  - /{id} 
-	 *  - /{id}/~{nb} 
-	 *  - /{id}/~{id2}
-	 *
-	 * The line number is computed by after parsing the yaml content with the
-	 * yaml parser. This latter returns a tree of Node, each corresponding to a
-	 * yaml construct and including a position.
-	 *
-	 * The Node matching the path is found by the methods findNode().
-	 */
-	private int getLine(JsonNode error, Node yamlTree) {
-		if (!error.has("instance") || !error.get("instance").has("pointer"))
-			return 1;
-
-		String path = error.get("instance").get("pointer").asText();
-
-		if (path == null || path.isEmpty())
-			return 1;
-
-		path = path.substring(1, path.length());
-		String[] strings = path.split("/");
-
-		if (yamlTree instanceof MappingNode) {
-			MappingNode mn = (MappingNode) yamlTree;
-
-			Node findNode = findNode(mn, Arrays.asList(strings));
-			if (findNode != null) {
-				return findNode.getStartMark().getLine() + 1;
-			}
-		}
-
-		return 1;
-	}
-
-	/*
-	 * Returns the yaml node that matches the given path.
-	 *
-	 * The path is given as a list of String. The Node matching the
-	 * path is found by traversing the children of the node pass as
-	 * first parameter.
-	 *
-	 */
-	private Node findNode(MappingNode root, List<String> paths) {
-		if (paths.isEmpty())
-			return root;
-
-		String path = paths.get(0);
-		if (path.startsWith("/")) {
-			path = path.substring(1, path.length());
-		}
-
-		final List<String> next = paths.subList(1, paths.size());
-		// ~1 is use to escape /
-		if (path.contains("~1")) {
-			path = path.replaceAll("~1", "/");
-		}
-
-		for (NodeTuple child : root.getValue()) {
-			if (child.getKeyNode() instanceof ScalarNode) {
-				ScalarNode scalar = (ScalarNode) child.getKeyNode();
-
-				if (scalar.getValue().equals(path)) {
-					return findNode(child, next);
-				}
-			}
-		}
-
-		return root;
-	}
-
-	private Node findNode(NodeTuple child, List<String> paths) {
-		if (child.getValueNode() instanceof MappingNode) {
-			return findNode((MappingNode) child.getValueNode(), paths);
-		}
-		return child.getKeyNode();
 	}
 
 }


### PR DESCRIPTION
This PR includes changes to support errors that span multiple schema.

Example new message for such errors

![screen shot 2016-01-21 at 18 42 39](https://cloud.githubusercontent.com/assets/148045/12489084/ec95b20a-c06e-11e5-9fbb-d70bc1686b85.png)
