### PR TITLE
#31, #97 - More Template Contexts

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -30,6 +30,8 @@ public class CodeTemplateContextTest {
 		assertThat(getContextType(":paths:"), not(equalTo(PathItemContextType.CONTEXT_ID)));
 		assertThat(getContextType(":paths:/pets:get"), not(equalTo(PathItemContextType.CONTEXT_ID)));
 		assertThat(getContextType(":paths:/pets:get:responses"), not(equalTo(PathItemContextType.CONTEXT_ID)));
+		assertThat(getContextType(":paths:/my-pets/v1/{pet-id}:somethingElse"),
+				not(equalTo(PathItemContextType.CONTEXT_ID)));
 	}
 
 	@Test
@@ -70,6 +72,15 @@ public class CodeTemplateContextTest {
 				equalTo(SchemaContextType.CONTEXT_ID));
 		assertThat(getContextType(":definitions:TaxFilingObject:additionalProperties"),
 				equalTo(SchemaContextType.CONTEXT_ID));
+	}
+
+	@Test
+	public void test$InRegex() throws Exception {
+		assertFalse("abcd".matches("abc"));
+		assertTrue("abc".matches("abc"));
+
+		assertFalse("abcd".matches("abc$"));
+		assertTrue("abc".matches("abc$"));
 	}
 
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -24,7 +24,8 @@ public class CodeTemplateContextTest {
 		assertThat(getContentType(":paths:/my-pets/v1/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
 		assertThat(getContentType(":paths:/pets"), equalTo(PathItemContextType.CONTEXT_ID));
 
-		// tests for #Templates defined in the Path context show in other contexts
+		// tests for #Templates defined in the Path context show in other
+		// contexts
 		assertThat(getContentType(":paths:"), not(equalTo(PathItemContextType.CONTEXT_ID)));
 		assertThat(getContentType(":paths:/pets:get"), not(equalTo(PathItemContextType.CONTEXT_ID)));
 		assertThat(getContentType(":paths:/pets:get:responses"), not(equalTo(PathItemContextType.CONTEXT_ID)));
@@ -58,6 +59,10 @@ public class CodeTemplateContextTest {
 		assertThat(getContentType(":paths:/pets/{id}:get:responses:200:schema:"),
 				equalTo(SchemaContextType.CONTEXT_ID));
 		assertThat(getContentType(":paths:/pets:post:parameters:@0:schema:"), equalTo(SchemaContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pets:post:parameters:@0:schema:properties:name"),
+				equalTo(SchemaContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pets:post:parameters:@0:schema:items"),
+				equalTo(SchemaContextType.CONTEXT_ID));
 	}
-	
+
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -1,0 +1,33 @@
+package com.reprezen.swagedit.tests;
+
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+import static com.reprezen.swagedit.templates.SwaggerContextType.getContentType;
+
+import org.junit.Test;
+
+import com.reprezen.swagedit.templates.SwaggerContextType.PathItemContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType.SecurityDefContextType;;
+
+public class CodeTemplateContextTest {
+
+	@Test
+	public void testPathItem() throws Exception {
+		assertThat(getContentType(":paths:/petstore"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
+		assertThat(getContentType(":paths:/pet-store"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
+		assertThat(getContentType(":paths:/pets/{id}"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
+		assertThat(getContentType(":paths:/pets/{pet-id}"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
+		assertThat(getContentType(":paths:/my-pets/{pet-id}"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
+		assertThat(getContentType(":paths:/my-pets/v1/{pet-id}"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
+		assertThat(getContentType(":paths:/pets"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
+
+		assertThat(getContentType(":paths:"), not(equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE)));
+		assertThat(getContentType(":paths:/pets:get"), not(equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE)));
+	}
+
+	@Test
+	public void testSecurityDef() throws Exception {
+		assertThat(getContentType(":securityDefinitions"), equalTo(SecurityDefContextType.SECURITY_DEF_CONTENT_TYPE));
+	}
+
+}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -2,10 +2,11 @@ package com.reprezen.swagedit.tests;
 
 import static org.junit.Assert.*;
 import static org.hamcrest.CoreMatchers.*;
-import static com.reprezen.swagedit.templates.SwaggerContextType.getContentType;
+import static com.reprezen.swagedit.templates.SwaggerContextType.getContextType;
 
 import org.junit.Test;
 
+import com.reprezen.swagedit.templates.SwaggerContextType.ParameterContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ParametersContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.PathItemContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ResponsesContextType;
@@ -16,53 +17,56 @@ public class CodeTemplateContextTest {
 
 	@Test
 	public void testPathItem() throws Exception {
-		assertThat(getContentType(":paths:/petstore"), equalTo(PathItemContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pet-store"), equalTo(PathItemContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pets/{id}"), equalTo(PathItemContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pets/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/my-pets/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/my-pets/v1/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pets"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/petstore"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/pet-store"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/pets/{id}"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/pets/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/my-pets/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/my-pets/v1/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/pets"), equalTo(PathItemContextType.CONTEXT_ID));
 
 		// tests for #Templates defined in the Path context show in other
 		// contexts
-		assertThat(getContentType(":paths:"), not(equalTo(PathItemContextType.CONTEXT_ID)));
-		assertThat(getContentType(":paths:/pets:get"), not(equalTo(PathItemContextType.CONTEXT_ID)));
-		assertThat(getContentType(":paths:/pets:get:responses"), not(equalTo(PathItemContextType.CONTEXT_ID)));
+		assertThat(getContextType(":paths:"), not(equalTo(PathItemContextType.CONTEXT_ID)));
+		assertThat(getContextType(":paths:/pets:get"), not(equalTo(PathItemContextType.CONTEXT_ID)));
+		assertThat(getContextType(":paths:/pets:get:responses"), not(equalTo(PathItemContextType.CONTEXT_ID)));
 	}
 
 	@Test
 	public void testSecurityDef() throws Exception {
-		assertThat(getContentType(":securityDefinitions"), equalTo(SecurityDefContextType.CONTEXT_ID));
+		assertThat(getContextType(":securityDefinitions"), equalTo(SecurityDefContextType.CONTEXT_ID));
 	}
 
 	@Test
 	public void testResponses() throws Exception {
-		assertThat(getContentType(":responses"), equalTo(ResponsesContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/resource:get:responses"), equalTo(ResponsesContextType.CONTEXT_ID));
+		assertThat(getContextType(":responses"), equalTo(ResponsesContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/resource:get:responses"), equalTo(ResponsesContextType.CONTEXT_ID));
 	}
 
 	@Test
-	public void testParameters() throws Exception {
-		assertThat(getContentType(":paths:/taxFilings/{id}:get:parameters:@0:"),
+	public void testParameter() throws Exception {
+		assertThat(getContextType(":parameters:skipParam:"), equalTo(ParameterContextType.CONTEXT_ID));
+	}
+
+	@Test
+	public void testParametersList() throws Exception {
+		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters:@0:"),
 				equalTo(ParametersContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/taxFilings/{id}:get:parameters"), equalTo(ParametersContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/resource:parameters:"), equalTo(ParametersContextType.CONTEXT_ID));
-		assertThat(getContentType(":parameters:skipParam:"), equalTo(ParametersContextType.CONTEXT_ID));
-		//assertThat(getContentType(":parameters"), equalTo(ParametersContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/resource:parameters:"), equalTo(ParametersContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters"), equalTo(ParametersContextType.CONTEXT_ID));
 	}
 
 	@Test
 	public void testSchema() throws Exception {
-		assertThat(getContentType(":definitions:Pet:"), equalTo(SchemaContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pets/{id}:delete:responses:default:schema:"),
+		assertThat(getContextType(":definitions:Pet:"), equalTo(SchemaContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/pets/{id}:delete:responses:default:schema:"),
 				equalTo(SchemaContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pets/{id}:get:responses:200:schema:"),
+		assertThat(getContextType(":paths:/pets/{id}:get:responses:200:schema:"),
 				equalTo(SchemaContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pets:post:parameters:@0:schema:"), equalTo(SchemaContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pets:post:parameters:@0:schema:properties:name"),
+		assertThat(getContextType(":paths:/pets:post:parameters:@0:schema:"), equalTo(SchemaContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/pets:post:parameters:@0:schema:properties:name"),
 				equalTo(SchemaContextType.CONTEXT_ID));
-		assertThat(getContentType(":paths:/pets:post:parameters:@0:schema:items"),
+		assertThat(getContextType(":paths:/pets:post:parameters:@0:schema:items"),
 				equalTo(SchemaContextType.CONTEXT_ID));
 	}
 

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -68,6 +68,8 @@ public class CodeTemplateContextTest {
 				equalTo(SchemaContextType.CONTEXT_ID));
 		assertThat(getContextType(":paths:/pets:post:parameters:@0:schema:items"),
 				equalTo(SchemaContextType.CONTEXT_ID));
+		assertThat(getContextType(":definitions:TaxFilingObject:additionalProperties"),
+				equalTo(SchemaContextType.CONTEXT_ID));
 	}
 
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -7,6 +7,7 @@ import static com.reprezen.swagedit.templates.SwaggerContextType.getContentType;
 import org.junit.Test;
 
 import com.reprezen.swagedit.templates.SwaggerContextType.PathItemContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType.ResponsesContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.SecurityDefContextType;;
 
 public class CodeTemplateContextTest {
@@ -28,6 +29,12 @@ public class CodeTemplateContextTest {
 	@Test
 	public void testSecurityDef() throws Exception {
 		assertThat(getContentType(":securityDefinitions"), equalTo(SecurityDefContextType.SECURITY_DEF_CONTENT_TYPE));
+	}
+
+	@Test
+	public void testResponses() throws Exception {
+		assertThat(getContentType(":responses"), equalTo(ResponsesContextType.CONTENT_TYPE));
+		assertThat(getContentType(":paths:/resource:get:responses"), equalTo(ResponsesContextType.CONTENT_TYPE));
 	}
 
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -48,7 +48,12 @@ public class CodeTemplateContextTest {
 
 	@Test
 	public void testParameterObject() throws Exception {
+		// top-level parameter definition
 		assertThat(getContextType(":parameters:skipParam:"), equalTo(ParameterObjectContextType.CONTEXT_ID));
+		// resource parameter
+		assertThat(getContextType(":paths:/taxFilings/{id}:parameters:@0:"),
+				equalTo(ParameterObjectContextType.CONTEXT_ID));
+		// method parameter
 		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters:@0:"),
 				equalTo(ParameterObjectContextType.CONTEXT_ID));
 	}
@@ -60,7 +65,9 @@ public class CodeTemplateContextTest {
 
 	@Test
 	public void testParametersList() throws Exception {
+		// resource parameters list
 		assertThat(getContextType(":paths:/resource:parameters:"), equalTo(ParametersListContextType.CONTEXT_ID));
+		// method parameters list
 		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters"),
 				equalTo(ParametersListContextType.CONTEXT_ID));
 	}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -7,7 +7,8 @@ import static com.reprezen.swagedit.templates.SwaggerContextType.getContextType;
 import org.junit.Test;
 
 import com.reprezen.swagedit.templates.SwaggerContextType.ParameterObjectContextType;
-import com.reprezen.swagedit.templates.SwaggerContextType.ParametersContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType.ParametersListContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType.ParametersListItemContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.PathItemContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ResponsesContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.SchemaContextType;
@@ -46,16 +47,18 @@ public class CodeTemplateContextTest {
 	}
 
 	@Test
-	public void testParameter() throws Exception {
+	public void testParameterObject() throws Exception {
 		assertThat(getContextType(":parameters:skipParam:"), equalTo(ParameterObjectContextType.CONTEXT_ID));
 	}
 
 	@Test
 	public void testParametersList() throws Exception {
 		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters:@0:"),
-				equalTo(ParametersContextType.CONTEXT_ID));
-		assertThat(getContextType(":paths:/resource:parameters:"), equalTo(ParametersContextType.CONTEXT_ID));
-		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters"), equalTo(ParametersContextType.CONTEXT_ID));
+				equalTo(ParametersListItemContextType.CONTEXT_ID));
+
+		assertThat(getContextType(":paths:/resource:parameters:"), equalTo(ParametersListContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters"),
+				equalTo(ParametersListContextType.CONTEXT_ID));
 	}
 
 	@Test

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -24,8 +24,10 @@ public class CodeTemplateContextTest {
 		assertThat(getContentType(":paths:/my-pets/v1/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
 		assertThat(getContentType(":paths:/pets"), equalTo(PathItemContextType.CONTEXT_ID));
 
+		// tests for #Templates defined in the Path context show in other contexts
 		assertThat(getContentType(":paths:"), not(equalTo(PathItemContextType.CONTEXT_ID)));
 		assertThat(getContentType(":paths:/pets:get"), not(equalTo(PathItemContextType.CONTEXT_ID)));
+		assertThat(getContentType(":paths:/pets:get:responses"), not(equalTo(PathItemContextType.CONTEXT_ID)));
 	}
 
 	@Test
@@ -57,4 +59,5 @@ public class CodeTemplateContextTest {
 				equalTo(SchemaContextType.CONTEXT_ID));
 		assertThat(getContentType(":paths:/pets:post:parameters:@0:schema:"), equalTo(SchemaContextType.CONTEXT_ID));
 	}
+	
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -6,9 +6,9 @@ import static com.reprezen.swagedit.templates.SwaggerContextType.getContextType;
 
 import org.junit.Test;
 
-import com.reprezen.swagedit.templates.SwaggerContextType.ParameterObjectContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType.ParameterDefinitionContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ParametersListContextType;
-import com.reprezen.swagedit.templates.SwaggerContextType.ParametersListItemContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType.ParameterObjectContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.PathItemContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ResponsesContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.SchemaContextType;
@@ -49,13 +49,17 @@ public class CodeTemplateContextTest {
 	@Test
 	public void testParameterObject() throws Exception {
 		assertThat(getContextType(":parameters:skipParam:"), equalTo(ParameterObjectContextType.CONTEXT_ID));
+		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters:@0:"),
+				equalTo(ParameterObjectContextType.CONTEXT_ID));
+	}
+
+	@Test
+	public void testParameterDefinition() throws Exception {
+		assertThat(getContextType(":parameters:"), equalTo(ParameterDefinitionContextType.CONTEXT_ID));
 	}
 
 	@Test
 	public void testParametersList() throws Exception {
-		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters:@0:"),
-				equalTo(ParametersListItemContextType.CONTEXT_ID));
-
 		assertThat(getContextType(":paths:/resource:parameters:"), equalTo(ParametersListContextType.CONTEXT_ID));
 		assertThat(getContextType(":paths:/taxFilings/{id}:get:parameters"),
 				equalTo(ParametersListContextType.CONTEXT_ID));

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -6,6 +6,7 @@ import static com.reprezen.swagedit.templates.SwaggerContextType.getContentType;
 
 import org.junit.Test;
 
+import com.reprezen.swagedit.templates.SwaggerContextType.ParametersContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.PathItemContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ResponsesContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.SecurityDefContextType;;
@@ -14,27 +15,34 @@ public class CodeTemplateContextTest {
 
 	@Test
 	public void testPathItem() throws Exception {
-		assertThat(getContentType(":paths:/petstore"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
-		assertThat(getContentType(":paths:/pet-store"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
-		assertThat(getContentType(":paths:/pets/{id}"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
-		assertThat(getContentType(":paths:/pets/{pet-id}"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
-		assertThat(getContentType(":paths:/my-pets/{pet-id}"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
-		assertThat(getContentType(":paths:/my-pets/v1/{pet-id}"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
-		assertThat(getContentType(":paths:/pets"), equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE));
+		assertThat(getContentType(":paths:/petstore"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pet-store"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pets/{id}"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pets/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/my-pets/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/my-pets/v1/{pet-id}"), equalTo(PathItemContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pets"), equalTo(PathItemContextType.CONTEXT_ID));
 
-		assertThat(getContentType(":paths:"), not(equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE)));
-		assertThat(getContentType(":paths:/pets:get"), not(equalTo(PathItemContextType.PATH_ITEM_CONTENT_TYPE)));
+		assertThat(getContentType(":paths:"), not(equalTo(PathItemContextType.CONTEXT_ID)));
+		assertThat(getContentType(":paths:/pets:get"), not(equalTo(PathItemContextType.CONTEXT_ID)));
 	}
 
 	@Test
 	public void testSecurityDef() throws Exception {
-		assertThat(getContentType(":securityDefinitions"), equalTo(SecurityDefContextType.SECURITY_DEF_CONTENT_TYPE));
+		assertThat(getContentType(":securityDefinitions"), equalTo(SecurityDefContextType.CONTEXT_ID));
 	}
 
 	@Test
 	public void testResponses() throws Exception {
-		assertThat(getContentType(":responses"), equalTo(ResponsesContextType.CONTENT_TYPE));
-		assertThat(getContentType(":paths:/resource:get:responses"), equalTo(ResponsesContextType.CONTENT_TYPE));
+		assertThat(getContentType(":responses"), equalTo(ResponsesContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/resource:get:responses"), equalTo(ResponsesContextType.CONTEXT_ID));
 	}
-
+	
+	@Test
+	public void testParameters() throws Exception {
+		assertThat(getContentType(":paths:/taxFilings/{id}:get:parameters:@0:"), equalTo(ParametersContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/taxFilings/{id}:get:parameters"), equalTo(ParametersContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/resource:parameters:"), equalTo(ParametersContextType.CONTEXT_ID));
+		assertThat(getContentType(":parameters:skipParam:"), equalTo(ParametersContextType.CONTEXT_ID));
+	}
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -49,6 +49,7 @@ public class CodeTemplateContextTest {
 		assertThat(getContentType(":paths:/taxFilings/{id}:get:parameters"), equalTo(ParametersContextType.CONTEXT_ID));
 		assertThat(getContentType(":paths:/resource:parameters:"), equalTo(ParametersContextType.CONTEXT_ID));
 		assertThat(getContentType(":parameters:skipParam:"), equalTo(ParametersContextType.CONTEXT_ID));
+		//assertThat(getContentType(":parameters"), equalTo(ParametersContextType.CONTEXT_ID));
 	}
 
 	@Test

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -9,6 +9,7 @@ import org.junit.Test;
 import com.reprezen.swagedit.templates.SwaggerContextType.ParametersContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.PathItemContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ResponsesContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType.SchemaContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.SecurityDefContextType;;
 
 public class CodeTemplateContextTest {
@@ -37,12 +38,23 @@ public class CodeTemplateContextTest {
 		assertThat(getContentType(":responses"), equalTo(ResponsesContextType.CONTEXT_ID));
 		assertThat(getContentType(":paths:/resource:get:responses"), equalTo(ResponsesContextType.CONTEXT_ID));
 	}
-	
+
 	@Test
 	public void testParameters() throws Exception {
-		assertThat(getContentType(":paths:/taxFilings/{id}:get:parameters:@0:"), equalTo(ParametersContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/taxFilings/{id}:get:parameters:@0:"),
+				equalTo(ParametersContextType.CONTEXT_ID));
 		assertThat(getContentType(":paths:/taxFilings/{id}:get:parameters"), equalTo(ParametersContextType.CONTEXT_ID));
 		assertThat(getContentType(":paths:/resource:parameters:"), equalTo(ParametersContextType.CONTEXT_ID));
 		assertThat(getContentType(":parameters:skipParam:"), equalTo(ParametersContextType.CONTEXT_ID));
+	}
+
+	@Test
+	public void testSchema() throws Exception {
+		assertThat(getContentType(":definitions:Pet:"), equalTo(SchemaContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pets/{id}:delete:responses:default:schema:"),
+				equalTo(SchemaContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pets/{id}:get:responses:200:schema:"),
+				equalTo(SchemaContextType.CONTEXT_ID));
+		assertThat(getContentType(":paths:/pets:post:parameters:@0:schema:"), equalTo(SchemaContextType.CONTEXT_ID));
 	}
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/CodeTemplateContextTest.java
@@ -6,7 +6,7 @@ import static com.reprezen.swagedit.templates.SwaggerContextType.getContextType;
 
 import org.junit.Test;
 
-import com.reprezen.swagedit.templates.SwaggerContextType.ParameterContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType.ParameterObjectContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ParametersContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.PathItemContextType;
 import com.reprezen.swagedit.templates.SwaggerContextType.ResponsesContextType;
@@ -47,7 +47,7 @@ public class CodeTemplateContextTest {
 
 	@Test
 	public void testParameter() throws Exception {
-		assertThat(getContextType(":parameters:skipParam:"), equalTo(ParameterContextType.CONTEXT_ID));
+		assertThat(getContextType(":parameters:skipParam:"), equalTo(ParameterObjectContextType.CONTEXT_ID));
 	}
 
 	@Test

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/SwaggerContentAssistProcessorTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/SwaggerContentAssistProcessorTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import com.reprezen.swagedit.assist.SwaggerContentAssistProcessor;
 import com.reprezen.swagedit.editor.SwaggerDocument;
-import com.reprezen.swagedit.templates.RootContextType;
 
 public class SwaggerContentAssistProcessorTest {
 
@@ -55,7 +54,7 @@ public class SwaggerContentAssistProcessorTest {
 		String yaml = "swa";
 		int offset = 3;
 
-		when(registry.getContextType(RootContextType.ROOT_CONTENT_TYPE)).thenReturn(null);
+		when(registry.getContextType(com.reprezen.swagedit.templates.SwaggerContextType.RootContextType.ROOT_CONTENT_TYPE)).thenReturn(null);
 		when(templateStore.getTemplates()).thenReturn(new Template[0]);
 		when(viewer.getDocument()).thenReturn(document);
 		when(viewer.getSelectedRange()).thenReturn(new Point(0, 0));

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/SwaggerContentAssistProcessorTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/SwaggerContentAssistProcessorTest.java
@@ -54,7 +54,7 @@ public class SwaggerContentAssistProcessorTest {
 		String yaml = "swa";
 		int offset = 3;
 
-		when(registry.getContextType(com.reprezen.swagedit.templates.SwaggerContextType.RootContextType.ROOT_CONTENT_TYPE)).thenReturn(null);
+		when(registry.getContextType(com.reprezen.swagedit.templates.SwaggerContextType.RootContextType.CONTEXT_ID)).thenReturn(null);
 		when(templateStore.getTemplates()).thenReturn(new Template[0]);
 		when(viewer.getDocument()).thenReturn(document);
 		when(viewer.getSelectedRange()).thenReturn(new Point(0, 0));

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/TestSuite.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/TestSuite.java
@@ -14,6 +14,7 @@ import com.reprezen.swagedit.validation.ErrorProcessorTest;
 	SwaggerSchemaTest.class,
 	ValidationMessageTest.class,
 	ValidatorTest.class,
-	ErrorProcessorTest.class
+	ErrorProcessorTest.class,
+	CodeTemplateContextTest.class
 })
 public class TestSuite {}

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -103,7 +103,7 @@
       </contextType>
       <contextType
             class="com.reprezen.swagedit.templates.SwaggerContextType$ParameterContextType"
-            id="com.reprezen.swagedit.templates.swagger.parameter_single"
+            id="com.reprezen.swagedit.templates.swagger.parameter_object"
             name="Individual Parameter Context">
       </contextType>
       <contextType

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -91,6 +91,12 @@
             id="com.reprezen.swagedit.templates.swagger.path_item"
             name="Path Item Context">
       </contextType>
+      <contextType
+            class="com.reprezen.swagedit.templates.SwaggerContextType$ResponsesContextType"
+            id="com.reprezen.swagedit.templates.swagger.responses"
+            name="Responses Context">
+      </contextType>
+
       <include file="resources/templates.xml"></include>
    </extension>
 

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -96,6 +96,11 @@
             id="com.reprezen.swagedit.templates.swagger.responses"
             name="Responses Context">
       </contextType>
+      <contextType
+            class="com.reprezen.swagedit.templates.SwaggerContextType$ParametersContextType"
+            id="com.reprezen.swagedit.templates.swagger.parameters"
+            name="Parameters Context">
+      </contextType>
 
       <include file="resources/templates.xml"></include>
    </extension>

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -98,8 +98,13 @@
       </contextType>
       <contextType
             class="com.reprezen.swagedit.templates.SwaggerContextType$ParametersContextType"
-            id="com.reprezen.swagedit.templates.swagger.parameters"
-            name="Parameters Context">
+            id="com.reprezen.swagedit.templates.swagger.parameters_list"
+            name="Parameters List Context">
+      </contextType>
+      <contextType
+            class="com.reprezen.swagedit.templates.SwaggerContextType$ParameterContextType"
+            id="com.reprezen.swagedit.templates.swagger.parameter_single"
+            name="Individual Parameter Context">
       </contextType>
       <contextType
             class="com.reprezen.swagedit.templates.SwaggerContextType$SchemaContextType"

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -101,6 +101,11 @@
             id="com.reprezen.swagedit.templates.swagger.parameters"
             name="Parameters Context">
       </contextType>
+      <contextType
+            class="com.reprezen.swagedit.templates.SwaggerContextType$SchemaContextType"
+            id="com.reprezen.swagedit.templates.swagger.schema"
+            name="Schema Context">
+      </contextType>
 
       <include file="resources/templates.xml"></include>
    </extension>

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -102,12 +102,12 @@
             name="Parameters List Context">
       </contextType>
       <contextType
-            class="com.reprezen.swagedit.templates.SwaggerContextType$ParametersListItemContextType"
-            id="com.reprezen.swagedit.templates.swagger.parameters_list_item"
+            class="com.reprezen.swagedit.templates.SwaggerContextType$ParameterDefinitionContextType"
+            id="com.reprezen.swagedit.templates.swagger.parameters_definition"
             name="Parameters List Context">
       </contextType>
       <contextType
-            class="com.reprezen.swagedit.templates.SwaggerContextType$ParameterContextType"
+            class="com.reprezen.swagedit.templates.SwaggerContextType$ParameterObjectContextType"
             id="com.reprezen.swagedit.templates.swagger.parameter_object"
             name="Individual Parameter Context">
       </contextType>

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -97,8 +97,13 @@
             name="Responses Context">
       </contextType>
       <contextType
-            class="com.reprezen.swagedit.templates.SwaggerContextType$ParametersContextType"
+            class="com.reprezen.swagedit.templates.SwaggerContextType$ParametersListContextType"
             id="com.reprezen.swagedit.templates.swagger.parameters_list"
+            name="Parameters List Context">
+      </contextType>
+      <contextType
+            class="com.reprezen.swagedit.templates.SwaggerContextType$ParametersListItemContextType"
+            id="com.reprezen.swagedit.templates.swagger.parameters_list_item"
             name="Parameters List Context">
       </contextType>
       <contextType

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -72,14 +72,24 @@
    <extension
          point="org.eclipse.ui.editors.templates">
       <contextType
-            class="com.reprezen.swagedit.templates.RootContextType"
+            class="com.reprezen.swagedit.templates.SwaggerContextType$RootContextType"
             id="com.reprezen.swagedit.templates.swagger.root"
-            name="Swagger Context">
+            name="Root Context">
       </contextType>
       <contextType
-            class="com.reprezen.swagedit.templates.PathContextType"
-            id="com.reprezen.swagedit.templates.swagger.path"
-            name="Path Context">
+            class="com.reprezen.swagedit.templates.SwaggerContextType$SecurityDefContextType"
+            id="com.reprezen.swagedit.templates.swagger.security_def"
+            name="Security Def Context">
+      </contextType>
+      <contextType
+            class="com.reprezen.swagedit.templates.SwaggerContextType$PathsContextType"
+            id="com.reprezen.swagedit.templates.swagger.paths"
+            name="Paths Context">
+      </contextType>
+      <contextType
+            class="com.reprezen.swagedit.templates.SwaggerContextType$PathItemContextType"
+            id="com.reprezen.swagedit.templates.swagger.path_item"
+            name="Path Item Context">
       </contextType>
       <include file="resources/templates.xml"></include>
    </extension>

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -28,10 +28,10 @@ info:
 </template>
 
      <template name="paths" 
- id="com.reprezen.swagedit.templates.paths_template" 
- description="swagger template" 
- context="com.reprezen.swagedit.templates.swagger.root" 
- enabled="true">
+       id="com.reprezen.swagedit.templates.paths_template" 
+       description="swagger template" 
+       context="com.reprezen.swagedit.templates.swagger.root" 
+       enabled="true">
 paths:
   /:
     get:
@@ -44,13 +44,13 @@ paths:
        id="com.reprezen.swagedit.templates.securityDef_oath2" 
        description="OAuth2 security def" 
        context="com.reprezen.swagedit.templates.swagger.security_def" 
-       enabled="true">oauth2:
- type: oauth2
- scopes:
-   user: Grants read/write access to profile info only.
- flow: accessCode
- authorizationUrl: https://github.com/login/oauth/authorize
- tokenUrl: https://github.com/login/oauth/access_token
+       enabled="true">OAuth2Scheme:
+  type: oauth2
+  scopes:
+    user: Grants read/write access to profile info only.
+  flow: accessCode
+  authorizationUrl: https://github.com/login/oauth/authorize
+  tokenUrl: https://github.com/login/oauth/access_token
 </template>     
      
      <template name="definitions" 

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -167,9 +167,21 @@ definitions:
 </template>
      
      <template name="integer parameter" 
-       id="com.reprezen.swagedit.templates.int_parameter_in_list" 
+       id="com.reprezen.swagedit.templates.int_parameter_list" 
        description="integer parameter template" 
        context="com.reprezen.swagedit.templates.swagger.parameters_list" 
+       enabled="true">- name: id
+  in: path
+  description: ID of the element
+  required: true
+  type: integer
+  format: int64
+</template>
+
+     <template name="integer parameter" 
+       id="com.reprezen.swagedit.templates.int_parameter_in_list" 
+       description="integer parameter template" 
+       context="com.reprezen.swagedit.templates.swagger.parameters_list_item" 
        enabled="true">- name: id
   in: path
   description: ID of the element

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -177,5 +177,18 @@ required: true
 type: integer
 format: int64
      </template>
+     
+     <template name="schema" 
+       id="com.reprezen.swagedit.templates.schema" 
+       description="schema template" 
+       context="com.reprezen.swagedit.templates.swagger.schema" 
+       enabled="true">required:
+      - name  
+    properties:
+      name:
+        type: string
+      tag:
+        type: string
+     </template>
  
  </templates>

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -167,9 +167,9 @@ definitions:
 </template>
      
      <template name="integer parameter" 
-       id="com.reprezen.swagedit.templates.int_parameter" 
+       id="com.reprezen.swagedit.templates.int_parameter_in_list" 
        description="integer parameter template" 
-       context="com.reprezen.swagedit.templates.swagger.parameters" 
+       context="com.reprezen.swagedit.templates.swagger.parameters_list" 
        enabled="true">- name: id
   in: path
   description: ID of the element
@@ -178,6 +178,19 @@ definitions:
   format: int64
 </template>
      
+     <template name="integer parameter" 
+       id="com.reprezen.swagedit.templates.int_parameter" 
+       description="integer parameter template" 
+       context="com.reprezen.swagedit.templates.swagger.parameter_single" 
+       enabled="true">param:
+  name: id
+  in: path
+  description: ID of the element
+  required: true
+  type: integer
+  format: int64
+</template>
+
      <template name="schema" 
        id="com.reprezen.swagedit.templates.schema" 
        description="schema template" 

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -6,7 +6,7 @@
        context="com.reprezen.swagedit.templates.swagger.root" 
        enabled="true">
 swagger: "2.0"
-     </template>
+</template>
 
      <template name="info" 
        id="com.reprezen.swagedit.templates.info_template" 
@@ -25,33 +25,33 @@ info:
   license:
     name: MIT
     url: http://opensource.org/licenses/MIT
-     </template>
+</template>
 
      <template name="paths" 
-       id="com.reprezen.swagedit.templates.paths_template" 
-       description="swagger template" 
-       context="com.reprezen.swagedit.templates.swagger.root" 
-       enabled="true">
+ id="com.reprezen.swagedit.templates.paths_template" 
+ description="swagger template" 
+ context="com.reprezen.swagedit.templates.swagger.root" 
+ enabled="true">
 paths:
   /:
     get:
       responses:
         '200':
           description: Ok
-     </template>
+</template>
      
      <template name="oath2" 
        id="com.reprezen.swagedit.templates.securityDef_oath2" 
        description="OAuth2 security def" 
        context="com.reprezen.swagedit.templates.swagger.security_def" 
        enabled="true">oauth2:
-    type: oauth2
-    scopes:
-      user: Grants read/write access to profile info only.
-    flow: accessCode
-    authorizationUrl: https://github.com/login/oauth/authorize
-    tokenUrl: https://github.com/login/oauth/access_token
-     </template>     
+ type: oauth2
+ scopes:
+   user: Grants read/write access to profile info only.
+ flow: accessCode
+ authorizationUrl: https://github.com/login/oauth/authorize
+ tokenUrl: https://github.com/login/oauth/access_token
+</template>     
      
      <template name="definitions" 
        id="com.reprezen.swagedit.templates.definitions_template" 
@@ -62,29 +62,29 @@ definitions:
   ${model}:
     title: "${model}"
     type: string
-     </template>
+</template>
      
      <template name="object resource" 
        id="com.reprezen.swagedit.templates.collection_resource_template" 
        description="object resource template" 
        context="com.reprezen.swagedit.templates.swagger.paths" 
        enabled="true">/resource:
-    get:
-      responses:
-        '200':
-          description: Ok
-     </template>     
+ get:
+   responses:
+     '200':
+       description: Ok
+</template>     
 
      <template name="collection resource" 
        id="com.reprezen.swagedit.templates.object_resource_template" 
        description="collection resource template" 
        context="com.reprezen.swagedit.templates.swagger.paths" 
        enabled="true">/resources:
-    get:
-      responses:
-        '200':
-          description: Ok
-     </template>   
+ get:
+   responses:
+     '200':
+       description: Ok
+</template>   
      
      <template name="get" 
        id="com.reprezen.swagedit.templates.path_get_template" 
@@ -96,31 +96,31 @@ definitions:
       responses:
         '200':
           description: OK
-     </template>
+</template>
 
      <template name="post" 
        id="com.reprezen.swagedit.templates.path_post_template" 
        description="POST template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">post:
-      summary:
-      description: 
-      responses:
-        '200':
-          description: OK
-     </template>
+ summary:
+ description: 
+ responses:
+   '200':
+     description: OK
+</template>
 
      <template name="put" 
        id="com.reprezen.swagedit.templates.path_put_template" 
        description="PUT template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">put:
-      summary:
-      description: 
-      responses:
-        '200':
-          description: OK
-     </template>
+ summary:
+ description: 
+ responses:
+   '200':
+     description: OK
+</template>
 
      <template name="delete" 
        id="com.reprezen.swagedit.templates.path_delete_template" 
@@ -132,39 +132,39 @@ definitions:
       responses:
         '200':
           description: OK
-     </template>
+</template>
     
     <template name="patch" 
        id="com.reprezen.swagedit.templates.path_patch_template" 
        description="PATCH template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">patch:
-      summary:
-      description: 
-      responses:
-        '200':
-          description: OK
-     </template>
+ summary:
+ description: 
+ responses:
+   '200':
+     description: OK
+</template>
 
     <template name="options" 
        id="com.reprezen.swagedit.templates.path_options_template" 
        description="OPTIONS template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">options:
-      summary:
-      description: 
-      responses:
-        '200':
-          description: OK
-     </template>
+ summary:
+ description: 
+ responses:
+   '200':
+     description: OK
+</template>
 
     <template name="OK response" 
        id="com.reprezen.swagedit.templates.ok_response" 
        description="OK template" 
        context="com.reprezen.swagedit.templates.swagger.responses" 
        enabled="true">200:
-   description: Ok
-     </template>
+ description: Ok
+</template>
      
      <template name="integer parameter" 
        id="com.reprezen.swagedit.templates.int_parameter" 
@@ -176,19 +176,19 @@ description: ID of the element
 required: true
 type: integer
 format: int64
-     </template>
+</template>
      
      <template name="schema" 
        id="com.reprezen.swagedit.templates.schema" 
        description="schema template" 
        context="com.reprezen.swagedit.templates.swagger.schema" 
        enabled="true">required:
-      - name  
-    properties:
-      name:
-        type: string
-      tag:
-        type: string
-     </template>
+  - name  
+properties:
+  name:
+    type: string
+  tag:
+    type: string
+</template>
  
  </templates>

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -163,6 +163,19 @@ definitions:
        description="OK template" 
        context="com.reprezen.swagedit.templates.swagger.responses" 
        enabled="true">200:
-          description: Ok
+   description: Ok
      </template>
+     
+     <template name="integer parameter" 
+       id="com.reprezen.swagedit.templates.int_parameter" 
+       description="integer parameter template" 
+       context="com.reprezen.swagedit.templates.swagger.parameters" 
+       enabled="true">name: id
+in: path
+description: ID of the element
+required: true
+type: integer
+format: int64
+     </template>
+ 
  </templates>

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -88,7 +88,7 @@ definitions:
      
      <template name="get" 
        id="com.reprezen.swagedit.templates.path_get_template" 
-       description="swagger template" 
+       description="GET template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">get:
       summary:
@@ -100,7 +100,7 @@ definitions:
 
      <template name="post" 
        id="com.reprezen.swagedit.templates.path_post_template" 
-       description="swagger template" 
+       description="POST template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">post:
       summary:
@@ -112,7 +112,7 @@ definitions:
 
      <template name="put" 
        id="com.reprezen.swagedit.templates.path_put_template" 
-       description="swagger template" 
+       description="PUT template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">put:
       summary:
@@ -124,7 +124,7 @@ definitions:
 
      <template name="delete" 
        id="com.reprezen.swagedit.templates.path_delete_template" 
-       description="swagger template" 
+       description="DELETE template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">delete:
       summary:
@@ -136,7 +136,7 @@ definitions:
     
     <template name="patch" 
        id="com.reprezen.swagedit.templates.path_patch_template" 
-       description="swagger template" 
+       description="PATCH template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">patch:
       summary:
@@ -148,7 +148,7 @@ definitions:
 
     <template name="options" 
        id="com.reprezen.swagedit.templates.path_options_template" 
-       description="swagger template" 
+       description="OPTIONS template" 
        context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">options:
       summary:
@@ -158,4 +158,11 @@ definitions:
           description: OK
      </template>
 
+    <template name="OK response" 
+       id="com.reprezen.swagedit.templates.ok_response" 
+       description="OK template" 
+       context="com.reprezen.swagedit.templates.swagger.responses" 
+       enabled="true">200:
+          description: Ok
+     </template>
  </templates>

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -181,7 +181,7 @@ definitions:
      <template name="integer parameter" 
        id="com.reprezen.swagedit.templates.int_parameter" 
        description="integer parameter template" 
-       context="com.reprezen.swagedit.templates.swagger.parameter_single" 
+       context="com.reprezen.swagedit.templates.swagger.parameter_object" 
        enabled="true">param:
   name: id
   in: path

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -167,40 +167,15 @@ definitions:
 </template>
      
      <template name="integer parameter" 
-       id="com.reprezen.swagedit.templates.int_parameter_list" 
-       description="integer parameter template" 
-       context="com.reprezen.swagedit.templates.swagger.parameters_list" 
-       enabled="true">- name: id
-  in: path
-  description: ID of the element
-  required: true
-  type: integer
-  format: int64
-</template>
-
-     <template name="integer parameter" 
-       id="com.reprezen.swagedit.templates.int_parameter_in_list" 
-       description="integer parameter template" 
-       context="com.reprezen.swagedit.templates.swagger.parameters_list_item" 
-       enabled="true">- name: id
-  in: path
-  description: ID of the element
-  required: true
-  type: integer
-  format: int64
-</template>
-     
-     <template name="integer parameter" 
-       id="com.reprezen.swagedit.templates.int_parameter" 
+       id="com.reprezen.swagedit.templates.int_parameter_object" 
        description="integer parameter template" 
        context="com.reprezen.swagedit.templates.swagger.parameter_object" 
-       enabled="true">param:
-  name: id
-  in: path
-  description: ID of the element
-  required: true
-  type: integer
-  format: int64
+       enabled="true">name: id
+in: path
+description: ID of the element
+required: true
+type: integer
+format: int64
 </template>
 
      <template name="schema" 

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -39,7 +39,20 @@ paths:
         '200':
           description: Ok
      </template>
-
+     
+     <template name="oath2" 
+       id="com.reprezen.swagedit.templates.securityDef_oath2" 
+       description="OAuth2 security def" 
+       context="com.reprezen.swagedit.templates.swagger.security_def" 
+       enabled="true">oauth2:
+    type: oauth2
+    scopes:
+      user: Grants read/write access to profile info only.
+    flow: accessCode
+    authorizationUrl: https://github.com/login/oauth/authorize
+    tokenUrl: https://github.com/login/oauth/access_token
+     </template>     
+     
      <template name="definitions" 
        id="com.reprezen.swagedit.templates.definitions_template" 
        description="swagger template" 
@@ -50,11 +63,33 @@ definitions:
     title: "${model}"
     type: string
      </template>
+     
+     <template name="object resource" 
+       id="com.reprezen.swagedit.templates.collection_resource_template" 
+       description="object resource template" 
+       context="com.reprezen.swagedit.templates.swagger.paths" 
+       enabled="true">/resource:
+    get:
+      responses:
+        '200':
+          description: Ok
+     </template>     
 
+     <template name="collection resource" 
+       id="com.reprezen.swagedit.templates.object_resource_template" 
+       description="collection resource template" 
+       context="com.reprezen.swagedit.templates.swagger.paths" 
+       enabled="true">/resources:
+    get:
+      responses:
+        '200':
+          description: Ok
+     </template>   
+     
      <template name="get" 
        id="com.reprezen.swagedit.templates.path_get_template" 
        description="swagger template" 
-       context="com.reprezen.swagedit.templates.swagger.path" 
+       context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">get:
       summary:
       description: 
@@ -66,7 +101,7 @@ definitions:
      <template name="post" 
        id="com.reprezen.swagedit.templates.path_post_template" 
        description="swagger template" 
-       context="com.reprezen.swagedit.templates.swagger.path" 
+       context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">post:
       summary:
       description: 
@@ -78,7 +113,7 @@ definitions:
      <template name="put" 
        id="com.reprezen.swagedit.templates.path_put_template" 
        description="swagger template" 
-       context="com.reprezen.swagedit.templates.swagger.path" 
+       context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">put:
       summary:
       description: 
@@ -90,7 +125,7 @@ definitions:
      <template name="delete" 
        id="com.reprezen.swagedit.templates.path_delete_template" 
        description="swagger template" 
-       context="com.reprezen.swagedit.templates.swagger.path" 
+       context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">delete:
       summary:
       description: 
@@ -102,7 +137,7 @@ definitions:
     <template name="patch" 
        id="com.reprezen.swagedit.templates.path_patch_template" 
        description="swagger template" 
-       context="com.reprezen.swagedit.templates.swagger.path" 
+       context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">patch:
       summary:
       description: 
@@ -114,7 +149,7 @@ definitions:
     <template name="options" 
        id="com.reprezen.swagedit.templates.path_options_template" 
        description="swagger template" 
-       context="com.reprezen.swagedit.templates.swagger.path" 
+       context="com.reprezen.swagedit.templates.swagger.path_item" 
        enabled="true">options:
       summary:
       description: 

--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -170,12 +170,12 @@ definitions:
        id="com.reprezen.swagedit.templates.int_parameter" 
        description="integer parameter template" 
        context="com.reprezen.swagedit.templates.swagger.parameters" 
-       enabled="true">name: id
-in: path
-description: ID of the element
-required: true
-type: integer
-format: int64
+       enabled="true">- name: id
+  in: path
+  description: ID of the element
+  required: true
+  type: integer
+  format: int64
 </template>
      
      <template name="schema" 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/Activator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/Activator.java
@@ -18,8 +18,7 @@ import org.eclipse.ui.plugin.AbstractUIPlugin;
 import org.osgi.framework.Bundle;
 import org.osgi.framework.BundleContext;
 
-import com.reprezen.swagedit.templates.PathContextType;
-import com.reprezen.swagedit.templates.RootContextType;
+import com.reprezen.swagedit.templates.SwaggerContextType;
 
 public class Activator extends AbstractUIPlugin {
 
@@ -107,6 +106,7 @@ public class Activator extends AbstractUIPlugin {
 			try {
 				templateStore.load();
 			} catch (IOException e) {
+				
 				YEditLog.logException(e);
 			}
 		}
@@ -116,8 +116,9 @@ public class Activator extends AbstractUIPlugin {
 	public ContextTypeRegistry getContextTypeRegistry() {
 		if (contextTypeRegistry == null) {
 			contextTypeRegistry = new ContributionContextTypeRegistry();
-			contextTypeRegistry.addContextType(RootContextType.ROOT_CONTENT_TYPE);
-			contextTypeRegistry.addContextType(PathContextType.PATH_CONTENT_TYPE);
+			for (String contextType : SwaggerContextType.allContextTypes()) {
+				contextTypeRegistry.addContextType(contextType);
+			}
 		}
 		return contextTypeRegistry;
 	}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
@@ -147,7 +147,7 @@ public class SwaggerContentAssistProcessor extends TemplateCompletionProcessor i
 
 	@Override
 	protected TemplateContextType getContextType(ITextViewer viewer, IRegion region) {
-		String contextType = SwaggerContextType.getContentType(currentPath);
+		String contextType = SwaggerContextType.getContextType(currentPath);
 		System.out.println("contextType " + contextType);
 		return getContextTypeRegistry().getContextType(contextType);
 	}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
@@ -8,11 +8,13 @@ import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.IRegion;
 import org.eclipse.jface.text.ITextSelection;
 import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.Position;
 import org.eclipse.jface.text.contentassist.ICompletionProposal;
 import org.eclipse.jface.text.contentassist.IContentAssistProcessor;
 import org.eclipse.jface.text.contentassist.IContextInformation;
 import org.eclipse.jface.text.contentassist.IContextInformationValidator;
 import org.eclipse.jface.text.templates.ContextTypeRegistry;
+import org.eclipse.jface.text.templates.DocumentTemplateContext;
 import org.eclipse.jface.text.templates.Template;
 import org.eclipse.jface.text.templates.TemplateCompletionProcessor;
 import org.eclipse.jface.text.templates.TemplateContext;
@@ -31,6 +33,7 @@ import com.reprezen.swagedit.Activator;
 import com.reprezen.swagedit.Activator.Icons;
 import com.reprezen.swagedit.editor.SwaggerDocument;
 import com.reprezen.swagedit.templates.SwaggerContextType;
+import com.reprezen.swagedit.templates.SwaggerTemplateContext;
 
 /**
  * This class provides basic content assist based on keywords used by the
@@ -128,8 +131,13 @@ public class SwaggerContentAssistProcessor extends TemplateCompletionProcessor i
 	}
 
 	@Override
-	protected ICompletionProposal createProposal(Template template, TemplateContext context, IRegion region, int relevance) {
-		return new StyledTemplateProposal(template, context, region, getImage(template), getTemplateLabel(template), relevance);
+	protected ICompletionProposal createProposal(Template template, TemplateContext context, IRegion region,
+			int relevance) {
+		if (context instanceof DocumentTemplateContext) {
+			context = new SwaggerTemplateContext((DocumentTemplateContext) context);
+		}
+		return new StyledTemplateProposal(template, context, region, getImage(template), getTemplateLabel(template),
+				relevance);
 	}
 
 	@Override

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
@@ -139,7 +139,9 @@ public class SwaggerContentAssistProcessor extends TemplateCompletionProcessor i
 
 	@Override
 	protected TemplateContextType getContextType(ITextViewer viewer, IRegion region) {
-		return getContextTypeRegistry().getContextType(SwaggerContextType.getContentType(currentPath));
+		String contextType = SwaggerContextType.getContentType(currentPath);
+		System.out.println("contextType " + contextType);
+		return getContextTypeRegistry().getContextType(contextType);
 	}
 
 	@Override

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/PathContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/PathContextType.java
@@ -1,9 +1,0 @@
-package com.reprezen.swagedit.templates;
-
-public class PathContextType extends SwaggerContextType {
-	public static final String PATH_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.path";
-
-	public PathContextType() {
-		super();
-	}
-}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/RootContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/RootContextType.java
@@ -1,5 +1,0 @@
-package com.reprezen.swagedit.templates;
-
-public class RootContextType extends SwaggerContextType {
-	public static final String ROOT_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.root";
-}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -49,11 +49,13 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:responses")) {
 			return ResponsesContextType.CONTEXT_ID;
 		}
-		if (/* path.equals(":parameters") || */ // is an object, not an array
-		path.matches(":parameters:[^:]*") //
-				|| path.matches(PATH_ITEM_REGEX + ":[^:]*:parameters(:@\\d+)?")
+		if (path.matches(PATH_ITEM_REGEX + ":[^:]*:parameters(:@\\d+)?")
 				|| path.matches(PATH_ITEM_REGEX + ":parameters")) {
 			return ParametersContextType.CONTEXT_ID;
+		}
+		if (path.equals(":parameters") //
+				|| path.matches(":parameters:[^:]*")) {
+			return ParameterContextType.CONTEXT_ID;
 		}
 		if (path.matches(":definitions:[^:]*") //
 				|| path.matches(PARAMETERS_SCHEMA_REGEX)//
@@ -73,6 +75,7 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				PathItemContextType.CONTEXT_ID, //
 				ResponsesContextType.CONTEXT_ID, //
 				ParametersContextType.CONTEXT_ID, //
+				ParameterContextType.CONTEXT_ID, //
 				SchemaContextType.CONTEXT_ID));
 	}
 
@@ -98,7 +101,11 @@ public abstract class SwaggerContextType extends TemplateContextType {
 	}
 
 	public static class ParametersContextType extends SwaggerContextType {
-		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters";
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters_list";
+	}
+
+	public static class ParameterContextType extends SwaggerContextType {
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameter_single";
 	}
 
 	public static class SchemaContextType extends SwaggerContextType {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -42,14 +42,19 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		if (path.matches(":paths:(/[^:]*)+")) { // /paths/[pathItem]/
 			return PathItemContextType.CONTEXT_ID;
 		}
-		if (path.equals(":responses") || path.matches(":paths:/[^:]*:[^:]*:responses")) {
+		if (path.equals(":responses")//
+				|| path.matches(":paths:/[^:]*:[^:]*:responses")) {
 			return ResponsesContextType.CONTEXT_ID;
 		}
-		if (path.matches(":parameters:[^:]*") || path.matches(":paths:/[^:]*:[^:]*:parameters(:@\\d+)?")
+		if (path.matches(":parameters:[^:]*") //
+				|| path.matches(":paths:/[^:]*:[^:]*:parameters(:@\\d+)?")
 				|| path.matches(":paths:/[^:]*:parameters")) {
 			return ParametersContextType.CONTEXT_ID;
 		}
-		if (path.matches(":definitions:[^:]*") || path.matches(".*:parameters(:@\\d+):schema")
+		if (path.matches(":definitions:[^:]*") //
+				|| path.matches(".*:parameters(:@\\d+):schema")//
+				|| path.matches(".*:parameters(:@\\d+):schema:items")//
+				|| path.matches(".*:parameters(:@\\d+):schema:properties:[^:]+")//
 				|| path.matches(".*:responses:[^:]*:schema")) {
 			return SchemaContextType.CONTEXT_ID;
 		}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -39,8 +39,11 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		if (path.equals(":paths")) {
 			return PathsContextType.PATHS_CONTENT_TYPE;
 		}
-		if (path.matches(":paths:(/[^:]*)+")) {
+		if (path.matches(":paths:(/[^:]*)+")) { // /paths/[pathItem]/
 			return PathItemContextType.PATH_ITEM_CONTENT_TYPE;
+		}
+		if (path.equals(":responses") || path.matches(":paths:/[^:]*:[^:]*:responses")) {
+			return ResponsesContextType.CONTENT_TYPE;
 		}
 		return null;
 	}
@@ -50,8 +53,8 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				RootContextType.ROOT_CONTENT_TYPE, //
 				SecurityDefContextType.SECURITY_DEF_CONTENT_TYPE, //
 				PathsContextType.PATHS_CONTENT_TYPE, //
-				PathItemContextType.PATH_ITEM_CONTENT_TYPE//
-		));
+				PathItemContextType.PATH_ITEM_CONTENT_TYPE, //
+				ResponsesContextType.CONTENT_TYPE));
 	}
 
 	public static class PathItemContextType extends SwaggerContextType {
@@ -69,6 +72,10 @@ public abstract class SwaggerContextType extends TemplateContextType {
 	public static class PathsContextType extends SwaggerContextType {
 		public static final String PATHS_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.paths";
 
+	}
+
+	public static class ResponsesContextType extends SwaggerContextType {
+		public static final String CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.responses";
 	}
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -1,7 +1,12 @@
 package com.reprezen.swagedit.templates;
 
+import java.util.Collection;
+import java.util.Collections;
+
 import org.eclipse.jface.text.templates.GlobalTemplateVariables;
 import org.eclipse.jface.text.templates.TemplateContextType;
+
+import com.google.common.collect.Lists;
 
 public abstract class SwaggerContextType extends TemplateContextType {
 
@@ -21,14 +26,49 @@ public abstract class SwaggerContextType extends TemplateContextType {
 	}
 
 	public static String getContentType(String path) {
-		if (path == null || path.isEmpty() || ":".equals(path))
-			return RootContextType.ROOT_CONTENT_TYPE;
-
-		if (path.matches(":paths:/\\D*")) {
-			return PathContextType.PATH_CONTENT_TYPE;
+		System.out.println("Context Type " + path);
+		if (path != null && path.endsWith(":")) {
+			path = path.substring(0, path.length() - 1);
 		}
-
+		if (path == null || path.isEmpty() || ":".equals(path)) {
+			return RootContextType.ROOT_CONTENT_TYPE;
+		}
+		if (path.equals(":securityDefinitions")) {
+			return SecurityDefContextType.SECURITY_DEF_CONTENT_TYPE;
+		}
+		if (path.equals(":paths")) {
+			return PathsContextType.PATHS_CONTENT_TYPE;
+		}
+		if (path.matches(":paths:(/[^:]*)+")) {
+			return PathItemContextType.PATH_ITEM_CONTENT_TYPE;
+		}
 		return null;
+	}
+
+	public static Collection<String> allContextTypes() {
+		return Collections.unmodifiableList(Lists.newArrayList(//
+				RootContextType.ROOT_CONTENT_TYPE, //
+				SecurityDefContextType.SECURITY_DEF_CONTENT_TYPE, //
+				PathsContextType.PATHS_CONTENT_TYPE, //
+				PathItemContextType.PATH_ITEM_CONTENT_TYPE//
+		));
+	}
+
+	public static class PathItemContextType extends SwaggerContextType {
+		public static final String PATH_ITEM_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.path_item";
+	}
+
+	public static class SecurityDefContextType extends SwaggerContextType {
+		public static final String SECURITY_DEF_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.security_def";
+	}
+
+	public static class RootContextType extends SwaggerContextType {
+		public static final String ROOT_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.root";
+	}
+
+	public static class PathsContextType extends SwaggerContextType {
+		public static final String PATHS_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.paths";
+
 	}
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -12,6 +12,9 @@ public abstract class SwaggerContextType extends TemplateContextType {
 
 	private static final String PARAMETERS_SCHEMA_REGEX = ".*:parameters(:@\\d+):schema";
 	private static final String PATH_ITEM_REGEX = ":paths:/[^:]+";
+	// we can use a ? here as both 'PATH_ITEM_REGEX + ":parameters$"' and
+	// 'PATH_ITEM_REGEX + ":[^:]+:parameters$"' are supported
+	private static final String PARAMETERS_LIST_REGEX = PATH_ITEM_REGEX + ":([^:]+:)?parameters";
 
 	public SwaggerContextType() {
 		addGlobalResolvers();
@@ -29,7 +32,7 @@ public abstract class SwaggerContextType extends TemplateContextType {
 	}
 
 	public static String getContextType(String path) {
-		// System.out.println("Context Type " + path);
+		//System.out.println("Context Type " + path);
 		if (path != null && path.endsWith(":")) {
 			path = path.substring(0, path.length() - 1);
 		}
@@ -49,18 +52,17 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:responses$")) {
 			return ResponsesContextType.CONTEXT_ID;
 		}
-		if (path.matches(PATH_ITEM_REGEX + ":parameters$") //
-				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:parameters$")) {
+		if (path.matches(PARAMETERS_LIST_REGEX + "$")) {
 			return ParametersListContextType.CONTEXT_ID;
 		}
-		if (path.matches(PATH_ITEM_REGEX + ":[^:]+:parameters:@\\d+$")) {
-			return ParametersListItemContextType.CONTEXT_ID;
-		}
-		if (path.matches(":parameters:[^:]+$")) {
+		if (path.matches(PARAMETERS_LIST_REGEX + ":@\\d+$")//
+				|| path.matches(":parameters:[^:]+$")) {
 			return ParameterObjectContextType.CONTEXT_ID;
 		}
-		if (path.equals(":parameters") //
-				|| path.matches(":definitions:[^:]+$") //
+		if (path.equals(":parameters")) {
+			return ParameterDefinitionContextType.CONTEXT_ID;
+		}
+		if (path.matches(":definitions:[^:]+$") //
 				|| path.matches(".+:[^:]+:additionalProperties$")//
 				|| path.matches(PARAMETERS_SCHEMA_REGEX + "$")//
 				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":items$")//
@@ -79,8 +81,8 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				PathItemContextType.CONTEXT_ID, //
 				ResponsesContextType.CONTEXT_ID, //
 				ParametersListContextType.CONTEXT_ID, //
-				ParametersListItemContextType.CONTEXT_ID, //
 				ParameterObjectContextType.CONTEXT_ID, //
+				ParameterDefinitionContextType.CONTEXT_ID, //
 				SchemaContextType.CONTEXT_ID));
 	}
 
@@ -109,12 +111,12 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters_list";
 	}
 
-	public static class ParametersListItemContextType extends SwaggerContextType {
-		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters_list_item";
-	}
-
 	public static class ParameterObjectContextType extends SwaggerContextType {
 		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameter_object";
+	}
+
+	public static class ParameterDefinitionContextType extends SwaggerContextType {
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameter_definition";
 	}
 
 	public static class SchemaContextType extends SwaggerContextType {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -10,6 +10,9 @@ import com.google.common.collect.Lists;
 
 public abstract class SwaggerContextType extends TemplateContextType {
 
+	private static final String PARAMETERS_SCHEMA_REGEX = ".*:parameters(:@\\d+):schema";
+	private static final String PATH_ITEM_REGEX = ":paths:/[^:]+";
+
 	public SwaggerContextType() {
 		addGlobalResolvers();
 	}
@@ -25,8 +28,8 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		addResolver(new GlobalTemplateVariables.User());
 	}
 
-	public static String getContentType(String path) {
-		//System.out.println("Context Type " + path);
+	public static String getContextType(String path) {
+		// System.out.println("Context Type " + path);
 		if (path != null && path.endsWith(":")) {
 			path = path.substring(0, path.length() - 1);
 		}
@@ -39,23 +42,23 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		if (path.equals(":paths")) {
 			return PathsContextType.CONTEXT_ID;
 		}
-		if (path.matches(":paths:(/[^:]*)+")) { // /paths/[pathItem]/
+		if (path.matches(PATH_ITEM_REGEX)) { // /paths/[pathItem]/
 			return PathItemContextType.CONTEXT_ID;
 		}
 		if (path.equals(":responses")//
-				|| path.matches(":paths:/[^:]*:[^:]*:responses")) {
+				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:responses")) {
 			return ResponsesContextType.CONTEXT_ID;
 		}
 		if (/* path.equals(":parameters") || */ // is an object, not an array
 		path.matches(":parameters:[^:]*") //
-				|| path.matches(":paths:/[^:]*:[^:]*:parameters(:@\\d+)?")
-				|| path.matches(":paths:/[^:]*:parameters")) {
+				|| path.matches(PATH_ITEM_REGEX + ":[^:]*:parameters(:@\\d+)?")
+				|| path.matches(PATH_ITEM_REGEX + ":parameters")) {
 			return ParametersContextType.CONTEXT_ID;
 		}
 		if (path.matches(":definitions:[^:]*") //
-				|| path.matches(".*:parameters(:@\\d+):schema")//
-				|| path.matches(".*:parameters(:@\\d+):schema:items")//
-				|| path.matches(".*:parameters(:@\\d+):schema:properties:[^:]+")//
+				|| path.matches(PARAMETERS_SCHEMA_REGEX)//
+				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":items")//
+				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":properties:[^:]+")//
 				|| path.matches(".*:responses:[^:]*:schema")) {
 			return SchemaContextType.CONTEXT_ID;
 		}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -29,7 +29,7 @@ public abstract class SwaggerContextType extends TemplateContextType {
 	}
 
 	public static String getContextType(String path) {
-		// System.out.println("Context Type " + path);
+		//System.out.println("Context Type " + path);
 		if (path != null && path.endsWith(":")) {
 			path = path.substring(0, path.length() - 1);
 		}
@@ -49,7 +49,7 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:responses")) {
 			return ResponsesContextType.CONTEXT_ID;
 		}
-		if (path.matches(PATH_ITEM_REGEX + ":[^:]*:parameters(:@\\d+)?")
+		if (path.matches(PATH_ITEM_REGEX + ":[^:]+:parameters(:@\\d+)?")
 				|| path.matches(PATH_ITEM_REGEX + ":parameters")) {
 			return ParametersContextType.CONTEXT_ID;
 		}
@@ -58,10 +58,11 @@ public abstract class SwaggerContextType extends TemplateContextType {
 			return ParameterContextType.CONTEXT_ID;
 		}
 		if (path.matches(":definitions:[^:]*") //
+				|| path.matches(".*:[^:]+:additionalProperties")//
 				|| path.matches(PARAMETERS_SCHEMA_REGEX)//
 				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":items")//
 				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":properties:[^:]+")//
-				|| path.matches(".*:responses:[^:]*:schema")) {
+				|| path.matches(".*:responses:[^:]+:schema")) {
 			return SchemaContextType.CONTEXT_ID;
 		}
 		return null;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -26,7 +26,7 @@ public abstract class SwaggerContextType extends TemplateContextType {
 	}
 
 	public static String getContentType(String path) {
-		System.out.println("Context Type " + path);
+		//System.out.println("Context Type " + path);
 		if (path != null && path.endsWith(":")) {
 			path = path.substring(0, path.length() - 1);
 		}
@@ -46,7 +46,8 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				|| path.matches(":paths:/[^:]*:[^:]*:responses")) {
 			return ResponsesContextType.CONTEXT_ID;
 		}
-		if (path.matches(":parameters:[^:]*") //
+		if (/* path.equals(":parameters") || */ // is an object, not an array
+		path.matches(":parameters:[^:]*") //
 				|| path.matches(":paths:/[^:]*:[^:]*:parameters(:@\\d+)?")
 				|| path.matches(":paths:/[^:]*:parameters")) {
 			return ParametersContextType.CONTEXT_ID;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -29,7 +29,7 @@ public abstract class SwaggerContextType extends TemplateContextType {
 	}
 
 	public static String getContextType(String path) {
-		//System.out.println("Context Type " + path);
+		// System.out.println("Context Type " + path);
 		if (path != null && path.endsWith(":")) {
 			path = path.substring(0, path.length() - 1);
 		}
@@ -42,27 +42,27 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		if (path.equals(":paths")) {
 			return PathsContextType.CONTEXT_ID;
 		}
-		if (path.matches(PATH_ITEM_REGEX)) { // /paths/[pathItem]/
+		if (path.matches(PATH_ITEM_REGEX + "$")) { // /paths/[pathItem]/
 			return PathItemContextType.CONTEXT_ID;
 		}
 		if (path.equals(":responses")//
-				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:responses")) {
+				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:responses$")) {
 			return ResponsesContextType.CONTEXT_ID;
 		}
-		if (path.matches(PATH_ITEM_REGEX + ":[^:]+:parameters(:@\\d+)?")
-				|| path.matches(PATH_ITEM_REGEX + ":parameters")) {
+		if (path.matches(PATH_ITEM_REGEX + ":[^:]+:parameters(:@\\d+)?$")
+				|| path.matches(PATH_ITEM_REGEX + ":parameters$")) {
 			return ParametersContextType.CONTEXT_ID;
 		}
 		if (path.equals(":parameters") //
-				|| path.matches(":parameters:[^:]*")) {
+				|| path.matches(":parameters:[^:]+$")) {
 			return ParameterContextType.CONTEXT_ID;
 		}
-		if (path.matches(":definitions:[^:]*") //
-				|| path.matches(".*:[^:]+:additionalProperties")//
-				|| path.matches(PARAMETERS_SCHEMA_REGEX)//
-				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":items")//
-				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":properties:[^:]+")//
-				|| path.matches(".*:responses:[^:]+:schema")) {
+		if (path.matches(":definitions:[^:]+$") //
+				|| path.matches(".+:[^:]+:additionalProperties$")//
+				|| path.matches(PARAMETERS_SCHEMA_REGEX + "$")//
+				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":items$")//
+				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":properties:[^:]+$")//
+				|| path.matches(".+:responses:[^:]+:schema$")) {
 			return SchemaContextType.CONTEXT_ID;
 		}
 		return null;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -49,15 +49,18 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:responses$")) {
 			return ResponsesContextType.CONTEXT_ID;
 		}
-		if (path.matches(PATH_ITEM_REGEX + ":[^:]+:parameters(:@\\d+)?$")
-				|| path.matches(PATH_ITEM_REGEX + ":parameters$")) {
-			return ParametersContextType.CONTEXT_ID;
+		if (path.matches(PATH_ITEM_REGEX + ":parameters$") //
+				|| path.matches(PATH_ITEM_REGEX + ":[^:]+:parameters$")) {
+			return ParametersListContextType.CONTEXT_ID;
 		}
-		if (path.equals(":parameters") //
-				|| path.matches(":parameters:[^:]+$")) {
+		if (path.matches(PATH_ITEM_REGEX + ":[^:]+:parameters:@\\d+$")) {
+			return ParametersListItemContextType.CONTEXT_ID;
+		}
+		if (path.matches(":parameters:[^:]+$")) {
 			return ParameterObjectContextType.CONTEXT_ID;
 		}
-		if (path.matches(":definitions:[^:]+$") //
+		if (path.equals(":parameters") //
+				|| path.matches(":definitions:[^:]+$") //
 				|| path.matches(".+:[^:]+:additionalProperties$")//
 				|| path.matches(PARAMETERS_SCHEMA_REGEX + "$")//
 				|| path.matches(PARAMETERS_SCHEMA_REGEX + ":items$")//
@@ -75,7 +78,8 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				PathsContextType.CONTEXT_ID, //
 				PathItemContextType.CONTEXT_ID, //
 				ResponsesContextType.CONTEXT_ID, //
-				ParametersContextType.CONTEXT_ID, //
+				ParametersListContextType.CONTEXT_ID, //
+				ParametersListItemContextType.CONTEXT_ID, //
 				ParameterObjectContextType.CONTEXT_ID, //
 				SchemaContextType.CONTEXT_ID));
 	}
@@ -101,8 +105,12 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.responses";
 	}
 
-	public static class ParametersContextType extends SwaggerContextType {
+	public static class ParametersListContextType extends SwaggerContextType {
 		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters_list";
+	}
+
+	public static class ParametersListItemContextType extends SwaggerContextType {
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters_list_item";
 	}
 
 	public static class ParameterObjectContextType extends SwaggerContextType {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -55,7 +55,7 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		}
 		if (path.equals(":parameters") //
 				|| path.matches(":parameters:[^:]+$")) {
-			return ParameterContextType.CONTEXT_ID;
+			return ParameterObjectContextType.CONTEXT_ID;
 		}
 		if (path.matches(":definitions:[^:]+$") //
 				|| path.matches(".+:[^:]+:additionalProperties$")//
@@ -76,7 +76,7 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				PathItemContextType.CONTEXT_ID, //
 				ResponsesContextType.CONTEXT_ID, //
 				ParametersContextType.CONTEXT_ID, //
-				ParameterContextType.CONTEXT_ID, //
+				ParameterObjectContextType.CONTEXT_ID, //
 				SchemaContextType.CONTEXT_ID));
 	}
 
@@ -105,8 +105,8 @@ public abstract class SwaggerContextType extends TemplateContextType {
 		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters_list";
 	}
 
-	public static class ParameterContextType extends SwaggerContextType {
-		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameter_single";
+	public static class ParameterObjectContextType extends SwaggerContextType {
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameter_object";
 	}
 
 	public static class SchemaContextType extends SwaggerContextType {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -31,51 +31,60 @@ public abstract class SwaggerContextType extends TemplateContextType {
 			path = path.substring(0, path.length() - 1);
 		}
 		if (path == null || path.isEmpty() || ":".equals(path)) {
-			return RootContextType.ROOT_CONTENT_TYPE;
+			return RootContextType.CONTEXT_ID;
 		}
 		if (path.equals(":securityDefinitions")) {
-			return SecurityDefContextType.SECURITY_DEF_CONTENT_TYPE;
+			return SecurityDefContextType.CONTEXT_ID;
 		}
 		if (path.equals(":paths")) {
-			return PathsContextType.PATHS_CONTENT_TYPE;
+			return PathsContextType.CONTEXT_ID;
 		}
 		if (path.matches(":paths:(/[^:]*)+")) { // /paths/[pathItem]/
-			return PathItemContextType.PATH_ITEM_CONTENT_TYPE;
+			return PathItemContextType.CONTEXT_ID;
 		}
 		if (path.equals(":responses") || path.matches(":paths:/[^:]*:[^:]*:responses")) {
-			return ResponsesContextType.CONTENT_TYPE;
+			return ResponsesContextType.CONTEXT_ID;
+		}
+		if (path.matches(":parameters:[^:]*") || path.matches(":paths:/[^:]*:[^:]*:parameters(:@\\d+)?")
+				|| path.matches(":paths:/[^:]*:parameters")) {
+			return ParametersContextType.CONTEXT_ID;
 		}
 		return null;
 	}
 
 	public static Collection<String> allContextTypes() {
 		return Collections.unmodifiableList(Lists.newArrayList(//
-				RootContextType.ROOT_CONTENT_TYPE, //
-				SecurityDefContextType.SECURITY_DEF_CONTENT_TYPE, //
-				PathsContextType.PATHS_CONTENT_TYPE, //
-				PathItemContextType.PATH_ITEM_CONTENT_TYPE, //
-				ResponsesContextType.CONTENT_TYPE));
+				RootContextType.CONTEXT_ID, //
+				SecurityDefContextType.CONTEXT_ID, //
+				PathsContextType.CONTEXT_ID, //
+				PathItemContextType.CONTEXT_ID, //
+				ResponsesContextType.CONTEXT_ID, //
+				ParametersContextType.CONTEXT_ID//
+		));
 	}
 
 	public static class PathItemContextType extends SwaggerContextType {
-		public static final String PATH_ITEM_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.path_item";
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.path_item";
 	}
 
 	public static class SecurityDefContextType extends SwaggerContextType {
-		public static final String SECURITY_DEF_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.security_def";
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.security_def";
 	}
 
 	public static class RootContextType extends SwaggerContextType {
-		public static final String ROOT_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.root";
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.root";
 	}
 
 	public static class PathsContextType extends SwaggerContextType {
-		public static final String PATHS_CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.paths";
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.paths";
 
 	}
 
 	public static class ResponsesContextType extends SwaggerContextType {
-		public static final String CONTENT_TYPE = "com.reprezen.swagedit.templates.swagger.responses";
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.responses";
 	}
 
+	public static class ParametersContextType extends SwaggerContextType {
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters";
+	}
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerContextType.java
@@ -49,6 +49,10 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				|| path.matches(":paths:/[^:]*:parameters")) {
 			return ParametersContextType.CONTEXT_ID;
 		}
+		if (path.matches(":definitions:[^:]*") || path.matches(".*:parameters(:@\\d+):schema")
+				|| path.matches(".*:responses:[^:]*:schema")) {
+			return SchemaContextType.CONTEXT_ID;
+		}
 		return null;
 	}
 
@@ -59,8 +63,8 @@ public abstract class SwaggerContextType extends TemplateContextType {
 				PathsContextType.CONTEXT_ID, //
 				PathItemContextType.CONTEXT_ID, //
 				ResponsesContextType.CONTEXT_ID, //
-				ParametersContextType.CONTEXT_ID//
-		));
+				ParametersContextType.CONTEXT_ID, //
+				SchemaContextType.CONTEXT_ID));
 	}
 
 	public static class PathItemContextType extends SwaggerContextType {
@@ -86,5 +90,9 @@ public abstract class SwaggerContextType extends TemplateContextType {
 
 	public static class ParametersContextType extends SwaggerContextType {
 		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.parameters";
+	}
+
+	public static class SchemaContextType extends SwaggerContextType {
+		public static final String CONTEXT_ID = "com.reprezen.swagedit.templates.swagger.schema";
 	}
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerTemplateContext.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerTemplateContext.java
@@ -22,9 +22,10 @@ import org.eclipse.jface.text.templates.TemplateTranslator;
 import org.eclipse.swt.widgets.Link;
 
 /**
- * Modification of {@link org.eclipse.xtext.ui.editor.templates.XtextTemplateContext}
- * with removed Xtext dependencies ({@link org.eclipse.xtext.scoping.IScopeProvider} and
- * {@link org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext})
+ * Modification of
+ * {@link org.eclipse.xtext.ui.editor.templates.XtextTemplateContext} with
+ * removed Xtext dependencies ({@link org.eclipse.xtext.scoping.IScopeProvider}
+ * and {@link org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext})
  * <br/>
  * <br/>
  * Represents an extended version of class {@link DocumentTemplateContext} to
@@ -36,14 +37,15 @@ import org.eclipse.swt.widgets.Link;
  * @author Sebastian Zarnekow
  */
 public class SwaggerTemplateContext extends DocumentTemplateContext {
-	
-	
+
 	public SwaggerTemplateContext(DocumentTemplateContext context) {
-		super(context.getContextType(), context.getDocument(), context.getCompletionOffset(), context.getCompletionLength());
+		super(context.getContextType(), context.getDocument(), context.getCompletionOffset(),
+				context.getCompletionLength());
 	}
-	
-	// Unmodified code from org.eclipse.xtext.ui.editor.templates.XtextTemplateContext below
-	
+
+	// Unmodified code from
+	// org.eclipse.xtext.ui.editor.templates.XtextTemplateContext below
+
 	@Override
 	public TemplateBuffer evaluate(Template template) throws BadLocationException, TemplateException {
 		if (!canEvaluate(template))
@@ -78,11 +80,22 @@ public class SwaggerTemplateContext extends DocumentTemplateContext {
 			IRegion lineRegion = getDocument().getLineInformationOfOffset(offset);
 			String line = getDocument().get(lineRegion.getOffset(), lineRegion.getLength());
 			int i = 0;
-			while (i < line.length() && Character.isWhitespace(line.charAt(i))) {
-				i++;
+			// support for array items
+			StringBuilder indentation = new StringBuilder();
+			while (i < line.length()) {
+				char indentSymbol = line.charAt(i);
+				if (Character.isWhitespace(indentSymbol)) {
+					indentation.append(indentSymbol);
+					i++;
+				} else if ('-' == indentSymbol) {// array item
+					indentation.append(' ');
+					i++;
+				} else {
+					break;
+				}
 			}
 			if (i != 0)
-				return new IndentationAwareTemplateTranslator(line.substring(0, i));
+				return new IndentationAwareTemplateTranslator(indentation.toString());
 			return new TemplateTranslator();
 		} catch (BadLocationException ex) {
 			return new TemplateTranslator();

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerTemplateContext.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/templates/SwaggerTemplateContext.java
@@ -1,0 +1,112 @@
+package com.reprezen.swagedit.templates;
+
+/*******************************************************************************
+ * Copyright (c) 2008 itemis AG (http://www.itemis.eu) and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *******************************************************************************/
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.templates.DocumentTemplateContext;
+import org.eclipse.jface.text.templates.Template;
+import org.eclipse.jface.text.templates.TemplateBuffer;
+import org.eclipse.jface.text.templates.TemplateContext;
+import org.eclipse.jface.text.templates.TemplateContextType;
+import org.eclipse.jface.text.templates.TemplateException;
+import org.eclipse.jface.text.templates.TemplateTranslator;
+import org.eclipse.swt.widgets.Link;
+
+/**
+ * Modification of {@link org.eclipse.xtext.ui.editor.templates.XtextTemplateContext}
+ * with removed Xtext dependencies ({@link org.eclipse.xtext.scoping.IScopeProvider} and
+ * {@link org.eclipse.xtext.ui.editor.contentassist.ContentAssistContext})
+ * <br/>
+ * <br/>
+ * Represents an extended version of class {@link DocumentTemplateContext} to
+ * provide additional Xtext related information and services for resolving a
+ * <code>Template</code>. Furthermore it fixes the indentation of the applied
+ * template.
+ * 
+ * @author Michael Clay - Initial contribution and API
+ * @author Sebastian Zarnekow
+ */
+public class SwaggerTemplateContext extends DocumentTemplateContext {
+	
+	
+	public SwaggerTemplateContext(DocumentTemplateContext context) {
+		super(context.getContextType(), context.getDocument(), context.getCompletionOffset(), context.getCompletionLength());
+	}
+	
+	// Unmodified code from org.eclipse.xtext.ui.editor.templates.XtextTemplateContext below
+	
+	@Override
+	public TemplateBuffer evaluate(Template template) throws BadLocationException, TemplateException {
+		if (!canEvaluate(template))
+			return null;
+
+		TemplateTranslator translator = createTemplateTranslator();
+		TemplateBuffer buffer = translator.translate(template);
+
+		getContextType().resolve(buffer, this);
+
+		return buffer;
+	}
+
+	/**
+	 * @since 2.3
+	 */
+	public TemplateBuffer evaluateForDisplay(Template template) throws BadLocationException, TemplateException {
+		if (!canEvaluate(template))
+			return null;
+
+		TemplateTranslator translator = new TemplateTranslator();
+		TemplateBuffer buffer = translator.translate(template);
+
+		getContextType().resolve(buffer, this);
+
+		return buffer;
+	}
+
+	protected TemplateTranslator createTemplateTranslator() {
+		try {
+			int offset = getStart();
+			IRegion lineRegion = getDocument().getLineInformationOfOffset(offset);
+			String line = getDocument().get(lineRegion.getOffset(), lineRegion.getLength());
+			int i = 0;
+			while (i < line.length() && Character.isWhitespace(line.charAt(i))) {
+				i++;
+			}
+			if (i != 0)
+				return new IndentationAwareTemplateTranslator(line.substring(0, i));
+			return new TemplateTranslator();
+		} catch (BadLocationException ex) {
+			return new TemplateTranslator();
+		}
+	}
+
+	public static class IndentationAwareTemplateTranslator extends TemplateTranslator {
+
+		private final String indentation;
+
+		public IndentationAwareTemplateTranslator(String indentation) {
+			this.indentation = indentation;
+		}
+
+		@Override
+		public TemplateBuffer translate(Template template) throws TemplateException {
+			return translate(template.getPattern());
+		}
+
+		@Override
+		public TemplateBuffer translate(String string) throws TemplateException {
+			String withIndentation = string.replaceAll("(\r\n?)|(\n)", "$0" + indentation);
+			return super.translate(withIndentation);
+		}
+	}
+
+}


### PR DESCRIPTION
This PR addresses the following issues:
#31 - More Template Contexts
#97 - Templates defined in the Path context show in other contexts

You can see all contexts and how they are defined in `SwaggerContextType`
Tests are in `CodeTemplateContextTest`
`SwaggerTemplateContext` provides support for indentation levels - we can use the same code template in different indentation levels.
## Code templates

Code templates are defined in `com.reprezen.swagedit/resources/templates.xml`
I provided very basic code templates for all context types just to make it easier to test this PR

Schema/allOf/[] is not supported yet because its format is different from other Schema elements
