### PR TITLE
#90 - Code assist for : use unqualified key for schema objects in #/definitions

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerProposalProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerProposalProvider.java
@@ -133,7 +133,7 @@ public class SwaggerProposalProvider {
 				String key = it.next();
 				
 				proposals.add( mapper.createObjectNode()
-						.put("value", "\"#/definitions/" + key + "\"")
+						.put("value", key)
 						.put("label", key)
 						.put("type", "ref") );
 			}


### PR DESCRIPTION
@tedepstein , it's a one-liner fix. Can you please review?
