### PR TITLE
#87 Reference candidate schemas by a descriptive name

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/schema.json
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/schema.json
@@ -1005,6 +1005,7 @@
               "$ref": "#/definitions/schema"
             },
             {
+              "title": "schema array",
               "type": "array",
               "minItems": 1,
               "items": {
@@ -1587,9 +1588,11 @@
     "format": {
       "anyOf": [
         {
+          "title": "user-defined format",
           "type": "string"
         },
         {
+          "title": "pre-defined format",
           "type": "string",
             "enum": [
               "int32",

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/schema.json
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/schema.json
@@ -991,6 +991,7 @@
               "$ref": "#/definitions/schema"
             },
             {
+              "title": "boolean",
               "type": "boolean"
             }
           ],

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
@@ -152,10 +152,6 @@ public class SwaggerError {
 			if (title != null) {
 				return title.asText();
 			}
-			JsonNode description = swaggerSchemaNode.get("title");
-			if (description != null) {
-				return description.asText();
-			}
 			// "$ref":"#/definitions/headerParameterSubSchema"
 			JsonNode ref = swaggerSchemaNode.get("$ref");
 			if (ref != null) {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
@@ -11,10 +11,12 @@
 package com.reprezen.swagedit.validation;
 
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 
 import org.eclipse.core.resources.IMarker;
 import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -108,6 +110,17 @@ public class SwaggerError {
 
 		@Override
 		public String getMessage() {
+			Set<String> orderedErrorLocations = new TreeSet<>(new Comparator<String>() {
+				@Override
+				public int compare(String o1, String o2) {
+					if (errors.get(o1).size() != errors.get(o2).size()) {
+						return errors.get(o1).size() - errors.get(o2).size();
+					}
+					return o1.compareTo(o2);
+				}
+			});
+			orderedErrorLocations.addAll(errors.keySet());
+
 			final StringBuilder builder = new StringBuilder();
 			final String tabs = Strings.repeat("\t", indent);
 
@@ -115,7 +128,7 @@ public class SwaggerError {
 			builder.append("Failed to match exactly one schema:");
 			builder.append("\n");
 
-			for (String location : errors.keySet()) {
+			for (String location : orderedErrorLocations) {
 				builder.append(tabs);
 				builder.append(" - ");
 				builder.append(getHumanFriendlyText(location));


### PR DESCRIPTION
@tedepstein, the new error message looks like this:
<img width="517" alt="screen shot 2016-03-04 at 4 55 09 pm" src="https://cloud.githubusercontent.com/assets/644582/13541403/ec8f3a56-e229-11e5-9c17-131a7af0a4df.png">

I replaced the location by a human readable label and sorted the messages so the best candidate (least amount of errors) is displayed first.
