### PR TITLE
#111, #79, Tests for #87 - Reference candidate schemas by a descriptive name

### DIFF
--- a/com.reprezen.swagedit.tests/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit.tests/META-INF/MANIFEST.MF
@@ -13,3 +13,4 @@ Require-Bundle: org.junit;bundle-version="4.0.0",
 Bundle-ClassPath: .,
  lib/mockito-core-1.10.19.jar,
  lib/objenesis-2.1.jar
+Bundle-Vendor: ModelSolv, Inc. d.b.a. RepreZen

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/TestSuite.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/tests/TestSuite.java
@@ -15,6 +15,7 @@ import org.junit.runners.Suite;
 import org.junit.runners.Suite.SuiteClasses;
 
 import com.reprezen.swagedit.validation.ErrorProcessorTest;
+import com.reprezen.swagedit.validation.MultipleSwaggerErrorMessageTest;
 
 @RunWith(Suite.class)
 @SuiteClasses({
@@ -24,7 +25,8 @@ import com.reprezen.swagedit.validation.ErrorProcessorTest;
 	SwaggerSchemaTest.class,
 	ValidationMessageTest.class,
 	ValidatorTest.class,
+	CodeTemplateContextTest.class,
 	ErrorProcessorTest.class,
-	CodeTemplateContextTest.class
+	MultipleSwaggerErrorMessageTest.class
 })
 public class TestSuite {}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ErrorProcessorTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ErrorProcessorTest.java
@@ -10,6 +10,7 @@
  *******************************************************************************/
 package com.reprezen.swagedit.validation;
 
+import static com.google.common.collect.Iterables.getOnlyElement;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -40,7 +41,7 @@ public class ErrorProcessorTest {
 		Set<SwaggerError> errors = processor.processMessageNode(fixture);
 
 		assertEquals(1, errors.size());
-		assertTrue(errors.iterator().next() instanceof SwaggerError);
+		assertTrue(getOnlyElement(errors) instanceof SwaggerError);
 	}
 
 	@Test
@@ -48,8 +49,8 @@ public class ErrorProcessorTest {
 		JsonNode fixture = mapper.readTree(Paths.get("resources", "error-2.json").toFile());
 		Set<SwaggerError> errors = processor.processMessageNode(fixture);
 
-		assertEquals(1, errors.size());	
-		assertTrue(errors.iterator().next() instanceof SwaggerError.MultipleSwaggerError);
+		assertEquals(1, errors.size());
+		assertTrue(getOnlyElement(errors) instanceof SwaggerError.MultipleSwaggerError);
 	}
 
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/MultipleSwaggerErrorMessageTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/MultipleSwaggerErrorMessageTest.xtend
@@ -9,6 +9,7 @@ import java.util.List
 import org.junit.Test
 
 import static org.junit.Assert.*
+import io.swagger.util.Json
 
 class MultipleSwaggerErrorMessageTest {
 
@@ -27,6 +28,42 @@ class MultipleSwaggerErrorMessageTest {
 		testCombinedSchemas("allOf")
 	}
 
+	@Test
+	def void testArrayOfSchemas() throws Exception {
+		val String defaultValue = "MY CRAZY DEFAULT VALUE FOR TESTS"
+		'''{
+		          "type": "array",
+		          "minItems": 1,
+«««		          a normal $ref
+		          "items": 
+		          {
+		            "$ref": "#/definitions/schema"
+		          }
+		        }'''.assertHumanFriendlyTextForNodeEquals("schema", defaultValue)
+		// test the case where the value of items is not a schema, but an array of schemas 
+		// as described in https://github.com/ModelSolv/SwagEdit/commit/dc1e222ec9be165b4f7774369bb7f168b6e940c1#commitcomment-16579761
+		'''{
+		          "type": "array",
+		          "minItems": 1,
+«««		          note that we use an array here
+		          "items": [
+		          {
+		            "$ref": "#/definitions/schema" 
+		          }, {
+		          	"$ref": "#/definitions/value2"
+		          }
+		          ]
+		        }'''.assertHumanFriendlyTextForNodeEquals(defaultValue, defaultValue)
+	}
+
+	def void assertHumanFriendlyTextForNodeEquals(CharSequence json, String expectedLabel, String defaultValue) {
+		val swaggerError = new SwaggerError.MultipleSwaggerError(0, 0);
+		val JsonNode arrayOfSchemasNode = Json.mapper().readTree(json.toString);
+		assertNotNull(arrayOfSchemasNode)
+		val label = swaggerError.getHumanFriendlyText(arrayOfSchemasNode, defaultValue);
+		assertEquals(expectedLabel, label)
+	}
+
 	def void testCombinedSchemas(String propertyName) throws Exception {
 		val JsonNode swaggerSchema = new JsonSchemaManager().getSwaggerSchema().asJson();
 		val swaggerError = new SwaggerError.MultipleSwaggerError(0, 0);
@@ -40,8 +77,8 @@ class MultipleSwaggerErrorMessageTest {
 			}
 		];
 		assertFalse(combinedSchemas.filterNull.isNullOrEmpty)
-		// println("All nodes: " + altValues)
-		// println("All labels: " + altValues.map[it|swaggerError.getHumanFriendlyText(it, null)])
+		// println("All nodes: " + combinedSchemas)
+		// println("All labels: " + combinedSchemas.map[it|swaggerError.getHumanFriendlyText(it, null)])
 		val emptyLabels = combinedSchemas.filter[it|Strings.isNullOrEmpty(swaggerError.getHumanFriendlyText(it, null))]
 		assertTrue("Null labels are not expected, but got null for the following nodes: " + emptyLabels,
 			emptyLabels.isNullOrEmpty)

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/MultipleSwaggerErrorMessageTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/MultipleSwaggerErrorMessageTest.xtend
@@ -1,0 +1,49 @@
+package com.reprezen.swagedit.validation
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.node.ArrayNode
+import com.google.common.base.Strings
+import com.google.common.collect.Lists
+import com.reprezen.swagedit.json.JsonSchemaManager
+import java.util.List
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+class MultipleSwaggerErrorMessageTest {
+
+	@Test
+	def void testAnyOf() throws Exception {
+		testCombinedSchemas("anyOf")
+	}
+
+	@Test
+	def void testOneOf() throws Exception {
+		testCombinedSchemas("oneOf")
+	}
+
+	@Test
+	def void testAllOf() throws Exception {
+		testCombinedSchemas("allOf")
+	}
+
+	def void testCombinedSchemas(String propertyName) throws Exception {
+		val JsonNode swaggerSchema = new JsonSchemaManager().getSwaggerSchema().asJson();
+		val swaggerError = new SwaggerError.MultipleSwaggerError(0, 0);
+		val List<JsonNode> combinedSchemas = newArrayList();
+		// oneOf and anyOf are usually ArrayNodes
+		swaggerSchema.findValues(propertyName).forEach [
+			if (it instanceof ArrayNode) {
+				combinedSchemas.addAll(Lists.newArrayList(it.elements))
+			} else {
+				combinedSchemas.add(it)
+			}
+		];
+		assertFalse(combinedSchemas.filterNull.isNullOrEmpty)
+		// println("All nodes: " + altValues)
+		// println("All labels: " + altValues.map[it|swaggerError.getHumanFriendlyText(it, null)])
+		val emptyLabels = combinedSchemas.filter[it|Strings.isNullOrEmpty(swaggerError.getHumanFriendlyText(it, null))]
+		assertTrue("Null labels are not expected, but got null for the following nodes: " + emptyLabels,
+			emptyLabels.isNullOrEmpty)
+	}
+}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/MultipleSwaggerErrorMessageTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/MultipleSwaggerErrorMessageTest.xtend
@@ -56,6 +56,23 @@ class MultipleSwaggerErrorMessageTest {
 		        }'''.assertHumanFriendlyTextForNodeEquals(defaultValue, defaultValue)
 	}
 
+	@Test
+	def void testArrayOfArraysSchema() throws Exception {
+		val String defaultValue = "MY CRAZY DEFAULT VALUE FOR TESTS"
+		'''{
+  "type": "array",
+  "minItems": 1,
+  "items": {
+    "type": "array",
+    "minItems": 1,
+    "items": {
+      "$ref": "#/definitions/foo"
+    }
+  }
+}'''.assertHumanFriendlyTextForNodeEquals("foo", defaultValue)
+
+	}
+
 	def void assertHumanFriendlyTextForNodeEquals(CharSequence json, String expectedLabel, String defaultValue) {
 		val swaggerError = new SwaggerError.MultipleSwaggerError(0, 0);
 		val JsonNode arrayOfSchemasNode = Json.mapper().readTree(json.toString);

--- a/com.reprezen.swagedit/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit/META-INF/MANIFEST.MF
@@ -56,3 +56,4 @@ Export-Package: com.reprezen.swagedit,
  com.reprezen.swagedit.templates,
  com.reprezen.swagedit.validation,
  com.reprezen.swagedit.wizards
+Bundle-Vendor: ModelSolv, Inc. d.b.a. RepreZen

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ErrorProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ErrorProcessor.java
@@ -65,7 +65,7 @@ public class ErrorProcessor {
 		return fromNode(message.asJson(), 0);
 	}
 
-	public Set<SwaggerError> processMessageNode(JsonNode value) {
+	/*package*/ Set<SwaggerError> processMessageNode(JsonNode value) {
 		return fromNode(value, 0);
 	}
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
@@ -143,21 +143,33 @@ public class SwaggerError {
 			return builder.toString();
 		}
 
-		protected String getHumanFriendlyText(String location) {
+		/* package */ String getHumanFriendlyText(String location) {
 			JsonNode swaggerSchemaNode = findNode(location);
 			if (swaggerSchemaNode == null) {
 				return location;
 			}
+			return getHumanFriendlyText(swaggerSchemaNode, location);
+		}
+
+		/* package */ String getHumanFriendlyText(JsonNode swaggerSchemaNode, String defaultValue) {
 			JsonNode title = swaggerSchemaNode.get("title");
 			if (title != null) {
 				return title.asText();
 			}
+			// nested array
+			if (swaggerSchemaNode.get("items") != null) {
+				swaggerSchemaNode = swaggerSchemaNode.get("items");
+			}
 			// "$ref":"#/definitions/headerParameterSubSchema"
 			JsonNode ref = swaggerSchemaNode.get("$ref");
 			if (ref != null) {
-				return ref.asText().substring(ref.asText().lastIndexOf("/") + 1);
+				return getLabelForRef(ref.asText());
 			}
-			return location;
+			return defaultValue;
+		}
+
+		/* package */ String getLabelForRef(String refValue) {
+			return refValue.substring(refValue.lastIndexOf("/") + 1);
 		}
 
 		protected JsonNode findNode(String path) {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
@@ -158,7 +158,7 @@ public class SwaggerError {
 			}
 			// nested array
 			if (swaggerSchemaNode.get("items") != null) {
-				swaggerSchemaNode = swaggerSchemaNode.get("items");
+				return getHumanFriendlyText(swaggerSchemaNode.get("items"), defaultValue);
 			}
 			// "$ref":"#/definitions/headerParameterSubSchema"
 			JsonNode ref = swaggerSchemaNode.get("$ref");

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
@@ -95,8 +95,8 @@ public class SwaggerError {
 			super(line, level, null);
 		}
 
-		public void put(String key, Set<SwaggerError> errors) {
-			this.errors.put(key, errors);
+		public void put(String path, Set<SwaggerError> errors) {
+			this.errors.put(path, errors);
 		}
 
 		public Map<String, Set<SwaggerError>> getErrors() {


### PR DESCRIPTION
The tests verify that the labels for options provided by "allOf", "anyOf" or "oneOf" are not empty.
@tedepstein , can you please review?
