### PR TITLE
#138 - objectResource template has improper indentation, causing error

### DIFF
--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -80,8 +80,8 @@ definitions:
     responses:
       '${200}':
         description: OK
-       schema:
-         $$ref: ${model}
+        schema:
+          $$ref: ${model}
 </template>     
 
      <template name="collection resource" 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerProposalProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerProposalProvider.java
@@ -143,7 +143,7 @@ public class SwaggerProposalProvider {
 				String key = it.next();
 				
 				proposals.add( mapper.createObjectNode()
-						.put("value", key)
+						.put("value", "\"#/definitions/" + key + "\"")
 						.put("label", key)
 						.put("type", "ref") );
 			}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetector.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetector.java
@@ -110,13 +110,9 @@ public class JsonReferenceHyperlinkDetector extends AbstractSwaggerHyperlinkDete
 
 			IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 			IPath extPath = new Path(filePath);
-            if (!extPath.isAbsolute()) {
-                try {
-                    extPath = new Path(fileInput.getURI().resolve(extPath.toOSString()).getPath());
-                } catch (IllegalArgumentException e) { // the given string violates RFC 2396
-                    return null;
-                }
-            }
+			if (!extPath.isAbsolute()) {
+				extPath = new Path(fileInput.getURI().resolve(extPath.toOSString()).getPath());
+			}
 
 			return root.getFileForLocation(extPath);
 		}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetector.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetector.java
@@ -110,9 +110,13 @@ public class JsonReferenceHyperlinkDetector extends AbstractSwaggerHyperlinkDete
 
 			IWorkspaceRoot root = ResourcesPlugin.getWorkspace().getRoot();
 			IPath extPath = new Path(filePath);
-			if (!extPath.isAbsolute()) {
-				extPath = new Path(fileInput.getURI().resolve(extPath.toOSString()).getPath());
-			}
+            if (!extPath.isAbsolute()) {
+                try {
+                    extPath = new Path(fileInput.getURI().resolve(extPath.toOSString()).getPath());
+                } catch (IllegalArgumentException e) { // the given string violates RFC 2396
+                    return null;
+                }
+            }
 
 			return root.getFileForLocation(extPath);
 		}


### PR DESCRIPTION
@tedepstein , I fixed the objectResource template.
Others seem to be fine.

As agreed at today's SUM, I also reverted a fix for #90 - "Code assist for : use unqualified key for schema objects in #/definitions ". 
