### PR TITLE
[#142] Failure to detect broken references

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetectorTest.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetectorTest.java
@@ -32,45 +32,23 @@ import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.hyperlink.IHyperlink;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.swagedit.editor.SwaggerDocument;
-import com.reprezen.swagedit.json.JsonDocumentManager;
-import com.reprezen.swagedit.json.references.JsonReference;
-import com.reprezen.swagedit.json.references.JsonReferenceFactory;
+import com.reprezen.swagedit.mocks.Mocks;
 
 public class JsonReferenceHyperlinkDetectorTest {
 
 	private ITextViewer viewer;
-	private JsonDocumentManager manager;
 	private URI uri;
 
 	protected JsonReferenceHyperlinkDetector detector(JsonNode document) {
-		when(manager.getDocument(Mockito.any(URI.class))).thenReturn(document);
-
-		return new JsonReferenceHyperlinkDetector() {
-			// allow running tests as non plugin tests
-			protected URI getBaseURI() {
-				return uri;
-			}
-
-			protected JsonReferenceFactory getFactory() {
-				return new JsonReferenceFactory() {
-					public JsonReference create(JsonNode node) {
-						JsonReference ref = super.create(node);
-						ref.setDocumentManager(manager);
-						return ref;
-					};
-				};
-			}
-		};
+		return Mocks.mockHyperlinkDetector(uri, document);
 	}
 
 	@Before
 	public void setUp() throws URISyntaxException {
 		viewer = mock(ITextViewer.class);
-		manager = mock(JsonDocumentManager.class);
 		uri = new URI(null, null, null);
 	}
 

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/mocks/Mocks.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/mocks/Mocks.java
@@ -1,0 +1,67 @@
+package com.reprezen.swagedit.mocks;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.Map;
+
+import org.eclipse.core.resources.IFile;
+import org.mockito.Mockito;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.swagedit.editor.hyperlinks.JsonReferenceHyperlinkDetector;
+import com.reprezen.swagedit.json.JsonDocumentManager;
+import com.reprezen.swagedit.json.references.JsonReference;
+import com.reprezen.swagedit.json.references.JsonReferenceFactory;
+
+public class Mocks {
+
+	public static JsonReferenceHyperlinkDetector mockHyperlinkDetector(final URI uri, final JsonNode document) {
+		final JsonDocumentManager manager = mock(JsonDocumentManager.class);
+		final IFile file = mock(IFile.class);
+
+		when(file.exists()).thenReturn(true);
+		when(manager.getDocument(Mockito.any(URI.class))).thenReturn(document);
+		when(manager.getFile(Mockito.any(URI.class))).thenReturn(file);
+
+		return new JsonReferenceHyperlinkDetector() {
+			// allow running tests as non plugin tests
+			protected URI getBaseURI() {
+				return uri;
+			}
+
+			protected JsonReferenceFactory getFactory() {
+				return new JsonReferenceFactory() {
+					public JsonReference create(JsonNode node) {
+						JsonReference ref = super.create(node);
+						ref.setDocumentManager(manager);
+						return ref;
+					};
+				};
+			}
+		};
+	}
+
+	public static JsonReferenceFactory mockJsonReferenceFactory(final Map<URI, JsonNode> entries) {
+		final IFile file = mock(IFile.class);
+		when(file.exists()).thenReturn(true);
+
+		return new JsonReferenceFactory() {
+			public JsonReference create(org.yaml.snakeyaml.nodes.ScalarNode node) {
+				JsonReference ref = super.create(node);
+				ref.setDocumentManager(new JsonDocumentManager() {
+					@Override
+					public IFile getFile(URI uri) {
+						return file;
+					}
+					@Override
+					public JsonNode getDocument(URI uri) {
+						return entries.get(uri);
+					}
+				});
+				return ref;
+			};
+		};
+	}
+}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
@@ -2,36 +2,24 @@ package com.reprezen.swagedit.validation
 
 import com.fasterxml.jackson.databind.JsonNode
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.reprezen.swagedit.Messages
 import com.reprezen.swagedit.editor.SwaggerDocument
-import com.reprezen.swagedit.json.JsonDocumentManager
-import com.reprezen.swagedit.json.references.JsonReferenceFactory
 import com.reprezen.swagedit.json.references.JsonReferenceValidator
+import com.reprezen.swagedit.mocks.Mocks
 import java.net.URI
+import java.util.Map
 import org.eclipse.core.resources.IMarker
 import org.junit.Test
-import org.yaml.snakeyaml.nodes.ScalarNode
 
 import static org.junit.Assert.*
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
-import java.util.Map
 
 class ReferenceValidatorTest {
-	
+
 	val document = new SwaggerDocument
 
 	def validator(Map<URI, JsonNode> entries) {
-		new JsonReferenceValidator(new JsonReferenceFactory {
-			override create(ScalarNode node) {
-				val ref = super.create(node)
-				ref.documentManager = new JsonDocumentManager {			
-					override getDocument(URI uri) {
-						entries.get(uri)
-					}			
-				}
-				ref
-			}
-		})
+		new JsonReferenceValidator(Mocks.mockJsonReferenceFactory(entries))
 	}
 
 	@Test

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/JsonDocumentManager.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/JsonDocumentManager.java
@@ -18,9 +18,12 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.WeakHashMap;
 
+import org.eclipse.core.resources.IFile;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.reprezen.swagedit.editor.DocumentUtils;
 
 /**
  * JsonDocumentManager
@@ -93,4 +96,16 @@ public class JsonDocumentManager {
 			return null;
 		}
 	}
+
+	/**
+	 * Returns the file located at the given URI if present 
+	 * in the workspace. Returns null otherwise.
+	 * 
+	 * @param uri - workspace file URI
+	 * @return file
+	 */
+	public IFile getFile(URI uri) {
+		return DocumentUtils.getWorkspaceFile(uri);
+	}
+
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReference.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReference.java
@@ -12,6 +12,7 @@ package com.reprezen.swagedit.json.references;
 
 import java.net.URI;
 
+import org.eclipse.core.resources.IFile;
 import org.yaml.snakeyaml.nodes.NodeId;
 import org.yaml.snakeyaml.nodes.NodeTuple;
 import org.yaml.snakeyaml.nodes.ScalarNode;
@@ -81,6 +82,10 @@ public class JsonReference {
 	public JsonNode resolve(URI baseURI) {
 		if (resolved == null) {
 			final URI resolvedURI = resolveURI(baseURI);
+			final IFile file = manager.getFile(resolvedURI);
+			if (file == null || !file.exists()) {
+				return null;
+			}
 			final JsonNode doc = manager.getDocument(resolvedURI);
 			if (doc != null) {
 				resolved = doc.at(pointer);


### PR DESCRIPTION
This commit modifies the JsonReference validation process by checking that the file the JsonReference URI is pointing at exists and is accessible. This is necessary to handle case sensitivity. The validation previously worked because validation was done on URIs and did not check that the file could be open. Hyperlinks to files with a different case than the one in the JsonReference previously failed but validation passed. Now, the JsonReference URI and the file name should have same case.
