### PR TITLE
[#150] External reference shows warning

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/JsonReferenceProposalProviderTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/JsonReferenceProposalProviderTest.xtend
@@ -68,6 +68,36 @@ class JsonReferenceProposalProviderTest {
 	}
 
 	@Test
+	def void shouldEncodeWhiteSpaceCharacters() {
+		val text = '''
+		paths:
+		  /foo:
+		    get:
+		      responses:
+		        '200':
+		          schema:
+		            $ref: 
+		          description: OK
+		definitions:
+		  Valid:
+		    type: string
+		'''
+
+		val document = new SwaggerDocument
+		document.set(text)
+
+		val path = Mocks.mockPath("../Path With Spaces/Other  Spaces.yaml")
+		val proposals = provider.collectProposals(document.asJson, "paths", path)
+
+		assertThat(proposals, hasItems(
+			mapper.createObjectNode
+				.put("value", "\"../Path%20With%20Spaces/Other%20%20Spaces.yaml#/paths/~1foo\"")
+				.put("label", "/foo")
+				.put("type", "../Path With Spaces/Other  Spaces.yaml#/paths/~1foo") as JsonNode
+		))
+	}
+
+	@Test
 	def void testContextTypes() {
 		// schema definitions
 		assertTrue(":paths:/foo:get:responses:200:schema:$ref".matches(JsonReferenceProposalProvider.SCHEMA_DEFINITION_REGEX))

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/mocks/Mocks.java
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/mocks/Mocks.java
@@ -69,7 +69,7 @@ public class Mocks {
 
 	public static IFile mockJsonReferenceProposalFile() {
 		IFile file = mock(IFile.class);
-		IContainer parent = mock(IContainer.class);		
+		IContainer parent = mock(IContainer.class);
 		IPath parentPath = mock(IPath.class);
 
 		when(file.getParent()).thenReturn(parent);
@@ -77,4 +77,11 @@ public class Mocks {
 		
 		return file;
 	}
+
+	public static IPath mockPath(String path) {
+		IPath mock = mock(IPath.class);
+		when(mock.toString()).thenReturn(path);
+		return mock;
+	}
+
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
@@ -255,6 +255,33 @@ class ReferenceValidatorTest {
 		))
 	}
 
+	@Test
+	def void should_ProduceError_If_URI_is_Invalid() {
+		val content = '''
+			swagger: '2.0'
+			info:
+			  version: 0.0.0
+			  title: Simple API
+			paths:
+			  /foo/{bar}:
+			    get:
+			      parameters:
+			        - $ref: 'contains space ref.yaml#/info/foo'
+			      responses:
+			        '200':
+			          description: OK
+		'''
+
+		document.set(content)
+		val baseURI = new URI(null, null, null)
+		val errors = validator(#{}).validate(baseURI, document.yaml)
+
+		assertEquals(1, errors.size())
+		assertTrue(errors.contains(
+			new SwaggerError(9, IMarker.SEVERITY_ERROR, Messages.error_invalid_reference)
+		))
+	}
+
 	def asJson(String string) {
 		new ObjectMapper(new YAMLFactory).readTree(string)
 	}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/JsonReferenceProposalProvider.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.reprezen.swagedit.assist;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
@@ -57,7 +59,7 @@ public class JsonReferenceProposalProvider extends AbstractProposalProvider {
 		final IPath basePath = currentFile.getParent().getFullPath();
 
 		if (scope == Scope.LOCAL) {
-			proposals.addAll(collectProposals(type, document.asJson(), null));
+			proposals.addAll(collectProposals(document.asJson(), type.value(), null));
 		} else {
 			IContainer parent;
 			if (scope == Scope.PROJECT) {
@@ -74,25 +76,11 @@ public class JsonReferenceProposalProvider extends AbstractProposalProvider {
 				JsonNode content = file.equals(currentFile) ? document.asJson() :
 					manager.getDocument(file.getLocationURI());
 
-				proposals.addAll(collectProposals(type, content, relative));
+				proposals.addAll(collectProposals(content, type.value(), relative));
 			}
 		}
 
 		return proposals;
-	}
-
-	protected Collection<JsonNode> collectProposals(ContextType type, JsonNode content, IPath relative) {
-		if (type == ContextType.SCHEMA_DEFINITION) {
-			return collectDefinitions(content, relative);
-		} else if (type == ContextType.PATH_ITEM) {
-			return collectPathItems(content, relative);
-		} else if (type == ContextType.PATH_PARAMETER) {
-			return collectParameters(content, relative);
-		} else if (type == ContextType.PATH_RESPONSE) {
-			return collectResponses(content, relative);
-		}
-
-		return Lists.newArrayList();
 	}
 
 	protected Iterable<IFile> collectFiles(IContainer parent) {
@@ -152,11 +140,20 @@ public class JsonReferenceProposalProvider extends AbstractProposalProvider {
 	 * has been activated.
 	 */
 	protected enum ContextType {
-		SCHEMA_DEFINITION,
-		PATH_ITEM,
-		PATH_PARAMETER,
-		PATH_RESPONSE,
-		UNKNOWN;
+		SCHEMA_DEFINITION("definitions"),
+		PATH_ITEM("paths"),
+		PATH_PARAMETER("parameters"),
+		PATH_RESPONSE("responses"),
+		UNKNOWN(null);
+
+		private final String value;
+		private ContextType(String value) {
+			this.value = value;
+		}
+
+		public String value() {
+			return value;
+		}
 
 		public static ContextType get(String path) {
 			if (Strings.emptyToNull(path) == null) {
@@ -177,88 +174,56 @@ public class JsonReferenceProposalProvider extends AbstractProposalProvider {
 		}
 	}
 
-	protected Collection<JsonNode> collectPathItems(JsonNode document, IPath path) {
-		Collection<JsonNode> results = Lists.newArrayList();
-
-		JsonNode parameters = document.get("paths");
-		if (parameters == null) {
+	/**
+	 * Returns all proposals found in the document at the specified field. 
+	 * 
+	 * @param document
+	 * @param fieldName
+	 * @param path
+	 * @return Collection of proposals
+	 */
+	protected Collection<JsonNode> collectProposals(JsonNode document, String fieldName, IPath path) {
+		final Collection<JsonNode> results = Lists.newArrayList();
+		if (fieldName == null || !document.has(fieldName)) {
 			return results;
 		}
 
-		for (Iterator<String> it = parameters.fieldNames(); it.hasNext();) {
-			String key = it.next();			
-			String value =  (path != null ? path.toString() : "") 
-					+ "#/paths/" + key.replaceAll("/", "~1");
-
-			results.add(mapper.createObjectNode()
-					.put("value", "\"" + value + "\"")
-					.put("label", key)
-					.put("type", value) );
-		}
-
-		return results;
-	}
-
-	protected Collection<JsonNode> collectParameters(JsonNode document, IPath path) {
-		Collection<JsonNode> results = Lists.newArrayList();
-
-		JsonNode parameters = document.get("parameters");
-		if (parameters == null) {
-			return results;
-		}
+		final JsonNode parameters = document.get(fieldName);
+		final String basePath = (path != null ? path.toString() : "") + "#/" + fieldName + "/";
 
 		for (Iterator<String> it = parameters.fieldNames(); it.hasNext();) {
 			String key = it.next();
-			String value =  (path != null ? path.toString() : "") + "#/parameters/" + key;
+			String value = basePath + key.replaceAll("/", "~1");
+			String encoded = encodeURL(value);
 
 			results.add(mapper.createObjectNode()
-					.put("value", "\"" + value + "\"")
+					.put("value", "\"" + encoded + "\"")
 					.put("label", key)
-					.put("type", value) );
+					.put("type", value));
 		}
 
 		return results;
 	}
 
-	protected Collection<JsonNode> collectResponses(JsonNode document, IPath path) {
-		Collection<JsonNode> results = Lists.newArrayList();
-
-		JsonNode parameters = document.get("responses");
-		if (parameters == null) {
-			return results;
+	/*
+	 * Encodes that path string so that it does not include illegal characters in 
+	 * respect to URL encoding. 
+	 * (see http://stackoverflow.com/questions/607176/java-equivalent-to-javascripts-encodeuricomponent-that-produces-identical-outpu)
+	 */
+	protected String encodeURL(String path) {
+		try {
+			return URLEncoder.encode(path, "UTF-8")
+					// decode characters that don't 
+					// need to be encoded.
+					.replaceAll("\\+", "%20")
+					.replaceAll("\\%21", "!")
+					.replaceAll("\\%2F", "/")
+					.replaceAll("\\%23", "#")
+					.replaceAll("\\%27", "'")
+					.replaceAll("\\%7E", "~");
+		} catch (UnsupportedEncodingException e) {
+			return path;
 		}
-
-		for (Iterator<String> it = parameters.fieldNames(); it.hasNext();) {
-			String key = it.next();
-			String value =  (path != null ? path.toString() : "") + "#/responses/" + key;
-
-			results.add(mapper.createObjectNode()
-					.put("value", "\"" + value + "\"")
-					.put("label", key)
-					.put("type", value) );
-		}
-
-		return results;
-	}
-
-	protected Collection<JsonNode> collectDefinitions(JsonNode document, IPath path) {
-		Collection<JsonNode> results = Lists.newArrayList();
-
-		if (document.has("definitions")) {
-			JsonNode definitions = document.get("definitions");
-
-			for (Iterator<String> it = definitions.fieldNames(); it.hasNext();) {
-				String key = it.next();
-				String value =  (path != null ? path.toString() : "") + "#/definitions/" + key;
-
-				results.add(mapper.createObjectNode()
-						.put("value", "\"" + value + "\"")
-						.put("label", key)
-						.put("type", value) );
-			}
-		}
-
-		return results;
 	}
 
 	private static class FileVisitor implements IResourceProxyVisitor {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetector.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetector.java
@@ -44,7 +44,7 @@ public class JsonReferenceHyperlinkDetector extends AbstractSwaggerHyperlinkDete
 		URI baseURI = getBaseURI();
 
 		JsonReference reference = getFactory().create(doc.getNodeForPath(basePath));
-		if (!reference.isValid(baseURI)) {
+		if (reference.isInvalid() || reference.isMissing(getBaseURI())) {
 			return null;
 		}
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReference.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReference.java
@@ -52,21 +52,31 @@ public class JsonReference {
 		this.manager = manager;
 	}
 
+	
 	/**
-	 * Returns true if the reference is valid, e.g. if this reference URI   
-	 * points to an existing JSON document and the pointer to an existing 
-	 * node inside that document.
+	 * Returns true if the reference was constructed from an invalid string, e.g. it 
+	 * contains invalid characters.
+	 * 
+	 * @return true if is invalid URI. 
+	 */
+	public boolean isInvalid() {
+		return uri == null;
+	}
+
+	/**
+	 * Returns true if the reference points to an existing JSON document and 
+	 * the pointer to an existing node inside that document.
 	 * 
 	 * @param baseURI
-	 * @return true if valid
+	 * @return true if the reference can be resolved.
 	 */
-	public boolean isValid(URI baseURI) {
-		if (uri == null) {
+	public boolean isMissing(URI baseURI) {
+		if (isInvalid()) {
 			return false;
 		}
 
 		JsonNode resolved = resolve(baseURI);
-		return resolved != null && !resolved.isMissingNode();
+		return resolved == null || resolved.isMissingNode();
 	}
 
 	/**

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReferenceFactory.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReferenceFactory.java
@@ -54,7 +54,7 @@ public class JsonReferenceFactory {
 			try {
 				uri = new URI(null, null, notNull.substring(1));
 			} catch (URISyntaxException e) {
-				uri = null;
+				return new JsonReference(null, null, false, false, source);
 			}
 		} else {
 			try {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReferenceValidator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReferenceValidator.java
@@ -60,27 +60,25 @@ public class JsonReferenceValidator {
 	protected Collection<? extends SwaggerError> doValidate(URI baseURI, Iterable<JsonReference> references) {
 		Set<SwaggerError> errors = Sets.newHashSet();
 		for (JsonReference reference: references) {
-			if (!reference.isValid(baseURI)) {
-				Object source = reference.getSource();
-
-				if (source instanceof Node) {
-					errors.add(createReferenceError((Node) source));
-				} else {
-					errors.add(createReferenceError());
-				}
+			if (reference.isInvalid()) {
+				errors.add(createReferenceError(IMarker.SEVERITY_ERROR, reference));
+			} else if (reference.isMissing(baseURI)) {
+				errors.add(createReferenceError(IMarker.SEVERITY_WARNING, reference));
 			}
 		}
 		return errors;
 	}
 
-	protected SwaggerError createReferenceError(Node node) {
-		int line = node.getStartMark().getLine() + 1;
+	protected SwaggerError createReferenceError(int severity, JsonReference reference) {
+		Object source = reference.getSource();
+		int line;
+		if (source instanceof Node) {
+			line = ((Node) source).getStartMark().getLine() + 1;
+		} else {
+			line = 1;
+		}
 
-		return new SwaggerError(line, IMarker.SEVERITY_WARNING, Messages.error_invalid_reference);
-	}
-
-	protected SwaggerError createReferenceError() {
-		return new SwaggerError(1, IMarker.SEVERITY_WARNING, Messages.error_invalid_reference);
+		return new SwaggerError(line, severity, Messages.error_invalid_reference);
 	}
 
 }


### PR DESCRIPTION
- Code assist for references now encode URLs (ex spaces are replaced with %20 characters)
- Illegal URI are now marked as errors and not warnings (URIs are considered illegals when contain invalid characters)
