### PR TITLE
[#115] Code assist for External references

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
@@ -19,6 +19,9 @@ public class Messages extends NLS {
 	// UI
 	public static String swagedit_wizard_title;
 	public static String swagedit_wizard_description;
+	public static String content_assist_proposal_local;
+	public static String content_assist_proposal_project;
+	public static String content_assist_proposal_workspace;
 
 	// errors
 	public static String error_typeNoMatch;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/AbstractProposalProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/AbstractProposalProvider.java
@@ -32,10 +32,11 @@ public abstract class AbstractProposalProvider {
 	 * Returns a list of completion proposals that are created from a single
 	 * proposal object.
 	 * 
-	 * @param path
-	 * @param document
-	 * @param prefix
-	 * @param documentOffset
+	 * @param path - path under current cursor
+	 * @param document - current swagger document
+	 * @param prefix - already typed characters 
+	 * @param documentOffset - offset of current cursor in document
+	 * @param cycle - current position in list of proposals 
 	 * @return list of completion proposals
 	 */
 	public Collection<? extends ICompletionProposal> getCompletionProposals(String path, SwaggerDocument document,

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/JsonReferenceProposalProvider.java
@@ -274,7 +274,7 @@ public class JsonReferenceProposalProvider extends AbstractProposalProvider {
 					files.add((IFile) proxy.requestResource());
 				}
 			} else if (proxy.getType() == IResource.FOLDER && 
-					(proxy.isDerived() || proxy.getName().equals("GenTargets"))) {
+					(proxy.isDerived() || proxy.getName().equalsIgnoreCase("gentargets"))) {
 				return false;
 			}
 			return true;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
@@ -103,16 +103,16 @@ public class SwaggerContentAssistProcessor extends TemplateCompletionProcessor i
 		String context;
 		switch(ContextType.get(currentPath)) {
 			case PATH_ITEM:
-				context = "path item";
+				context = "path items";
 				break;
 			case PATH_PARAMETER:
-				context = "parameter";
+				context = "parameters";
 				break;
 			case PATH_RESPONSE:
-				context = "response";
+				context = "responses";
 				break;
 			default:
-				context = "schema";
+				context = "schemas";
 				break;
 		}
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
@@ -24,3 +24,6 @@ error_cannot_read_content = Unable to read content. It may be invalid YAML
 error_invalid_reference = Invalid Reference - SwagEdit was unable to resolve the reference. \n\
 The value must be a valid JSON Reference (for external references) or JSON Pointer (for local references), and must resolve to an object of the expected type.
 
+content_assist_proposal_local = Press '%s' to show %s in the current file.
+content_assist_proposal_project = Press '%s' to show all %s in the project.
+content_assist_proposal_workspace = Press '%s' to show all %s in the workspace.


### PR DESCRIPTION
This commit fixes the key binding that appears in the content assist prompt, and also makes this text message dynamic depending on the item types.
Also fixes the GenTargets folder case and contains updates to javadocs.
