### PR TITLE
#166 NullPointerException if a reference has a space following the "#" (e.g. `# /definitions/Pet`)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,6 @@ hs_err_pid*
 
 # maven build results
 target/
+
+# Xtend Gen folder
+xtend-gen/

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReference.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReference.java
@@ -58,7 +58,7 @@ public class JsonReference {
      * @return true if is invalid URI.
      */
     public boolean isInvalid() {
-        return uri == null;
+        return uri == null || pointer == null;
     }
 
     /**
@@ -95,7 +95,11 @@ public class JsonReference {
             }
             final JsonNode doc = manager.getDocument(resolvedURI);
             if (doc != null) {
-                resolved = doc.at(pointer);
+                try {
+                    resolved = doc.at(pointer);
+                } catch (Exception e) {
+                    // ignore, the value will be null
+                }
             }
         }
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReferenceFactory.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReferenceFactory.java
@@ -65,7 +65,12 @@ public class JsonReferenceFactory {
         }
 
         String fragment = uri.getFragment();
-        JsonPointer pointer = JsonPointer.compile(Strings.emptyToNull(fragment));
+        JsonPointer pointer = null;
+        try {
+            pointer = JsonPointer.compile(Strings.emptyToNull(fragment));
+        } catch (IllegalArgumentException e) {
+            // let the pointer be null
+        }
 
         uri = uri.normalize();
         boolean absolute = uri.isAbsolute();


### PR DESCRIPTION
This PR addresses all three aspects of #166 
1. Fix NPE
2. Report an error, not a warning, as in other cases with invalid ref strings
3. The modal dialog was caused by an exception inside an Eclipse Job. Make our Eclipse Jobs used for validation more resilient to potential exception, at least, don't show a dialog.

@ghillairet , can you please review?
