### PR TITLE
#169 - Empty swagger model (with  text) does not show an error in SwagEdit

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -43,7 +43,6 @@ import org.eclipse.jface.text.source.projection.ProjectionSupport;
 import org.eclipse.jface.text.source.projection.ProjectionViewer;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
-import org.eclipse.jface.viewers.TreeViewer;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.custom.StackLayout;
 import org.eclipse.swt.layout.FillLayout;
@@ -56,7 +55,7 @@ import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IFileEditorInput;
 import org.yaml.snakeyaml.error.YAMLException;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.reprezen.swagedit.Activator;
 import com.reprezen.swagedit.validation.SwaggerError;
 import com.reprezen.swagedit.validation.Validator;
@@ -386,8 +385,8 @@ public class SwaggerEditor extends YEdit {
         if (document.getYamlError() instanceof YAMLException) {
             addMarker(new SwaggerError((YAMLException) document.getYamlError()), file, document);
         }
-        if (document.getJsonError() instanceof JsonParseException) {
-            addMarker(new SwaggerError((JsonParseException) document.getJsonError()), file, document);
+        if (document.getJsonError() instanceof JsonProcessingException) {
+            addMarker(new SwaggerError((JsonProcessingException) document.getJsonError()), file, document);
         }
     }
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/SwaggerError.java
@@ -22,7 +22,7 @@ import org.eclipse.core.resources.IMarker;
 import org.yaml.snakeyaml.error.MarkedYAMLException;
 import org.yaml.snakeyaml.error.YAMLException;
 
-import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
@@ -62,7 +62,7 @@ public class SwaggerError {
         }
     }
 
-    public SwaggerError(JsonParseException exception) {
+    public SwaggerError(JsonProcessingException exception) {
         this.level = IMarker.SEVERITY_ERROR;
         this.message = exception.getMessage();
 


### PR DESCRIPTION
Trial fix. The error marker is now shown, but its text can be improved:
![screen shot 2016-07-29 at 17 58 06](https://cloud.githubusercontent.com/assets/644582/17264613/3b8d994a-55b6-11e6-961a-f86f508e473b.png)

Please don't close the issue until the error text is made more human-friendly.
@ghillairet can you please review?
