### PR TITLE
[#180] Strange error markers when machine is offline

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ErrorProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ErrorProcessor.java
@@ -124,8 +124,12 @@ public class ErrorProcessor {
     }
 
     protected String rewriteError(JsonNode error) {
-        if (error == null || !error.has("keyword")) {
+        if (error == null) {
             return "";
+        }
+
+        if (!error.has("keyword")) {
+            return error.has("message") ? error.get("message").asText() : "";
         }
 
         switch (error.get("keyword").asText()) {


### PR DESCRIPTION
#180

An exception will be thrown if no internet connection is available since the swagger schema references the base json schema located at http://json-schema.org/draft-04/schema.
This commit makes sure the message related to this error is translated into a marker.
