### PR TITLE
ZEN-2914 - loosen requirements for YEdit dependency

### DIFF
--- a/com.reprezen.swagedit.feature/feature.xml
+++ b/com.reprezen.swagedit.feature/feature.xml
@@ -105,7 +105,7 @@ This Agreement is governed by the laws of the State of New York and the intellec
       <import plugin="org.eclipse.core.resources"/>
       <import plugin="org.eclipse.ui.ide"/>
       <import plugin="org.eclipse.ui.workbench.texteditor"/>
-      <import plugin="org.dadacoalition.yedit" version="1.0.20" match="greaterOrEqual"/>
+      <import plugin="org.dadacoalition.yedit" version="1.0.15" match="greaterOrEqual"/>
    </requires>
 
    <plugin

--- a/com.reprezen.swagedit/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit/META-INF/MANIFEST.MF
@@ -13,7 +13,7 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.core.resources,
  org.eclipse.ui.ide,
  org.eclipse.ui.workbench.texteditor,
- org.dadacoalition.yedit;bundle-version="1.0.20",
+ org.dadacoalition.yedit,
  com.github.eclipsecolortheme;resolution:=optional
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7


### PR DESCRIPTION
Current SwagEdit requires the most recent YEdit to be installed. As a
result, SwagEdit cannot be installed on top of installations that
require older versions of YEdit, e.g. http://www.nodeclipse.org/. It
requires 1.0.15, not older, not newer. 

I modified our dependency on YEdit, so we now accept YEdit 1.0.15+ .
I tested this installation manually - installed withput problems, code
assist, code templates, and validation work as expected.
The release notes for YEdit (https://github.com/oyse/yedit/releases)
don't contain any incompatible change  between versions 1.0.15 and
1.0.20.

When update site created by this PR is installed on top of Eclipse with  YEdit 1.0.15 the old version of Yedit is preserved: 
<img width="915" alt="screen shot 2016-09-26 at 2 41 09 pm" src="https://cloud.githubusercontent.com/assets/644582/18847722/42b29466-83f9-11e6-8623-888b41682ab5.png">
