### PR TITLE
Content assist enhancements 

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
@@ -128,7 +128,6 @@ class SwaggerContentAssistProcessorTest {
 			hasItems(
 				"uniqueItems:",
 				"format:",
-				"default:",
 				"maxItems:",
 				"$ref:",
 				"schema:",
@@ -155,7 +154,6 @@ class SwaggerContentAssistProcessorTest {
 			hasItems(
 				"uniqueItems:",
 				"format:",
-				"default:",
 				"maxItems:",
 				"$ref:",
 				"schema:",
@@ -168,4 +166,22 @@ class SwaggerContentAssistProcessorTest {
 			))
 	}
 
+	@Test
+	def void test3() {
+		val test = setUpContentAssistTest('''
+		 definitions:
+		  Product:
+		    <1>required:
+		      - name  
+		    properties:
+		      name:
+		        type: string
+		      description:
+		        type: <2>
+		''', new SwaggerDocument)
+		
+		var proposals = test.apply(processor, "1")
+		proposals = test.apply(processor, "2")
+//		println(proposals.map[(it as StyledCompletionProposal).replacementString])
+	}
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerProposalProviderTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerProposalProviderTest.xtend
@@ -11,6 +11,7 @@ import org.junit.Test
 
 import static org.hamcrest.core.IsCollectionContaining.*
 import static org.junit.Assert.*
+import com.reprezen.swagedit.schema.ComplexTypeDefinition
 
 class SwaggerProposalProviderTest {
 
@@ -201,5 +202,19 @@ class SwaggerProposalProviderTest {
 			"binary",
 			"date"
 		))
+	}
+	
+	@Test
+	def void testGetParameterRequired() {
+		val node = new ObjectNode(null, "/parameters/foo".ptr)
+		node.type = schema.getType(node)
+
+		assertTrue(node.type instanceof ComplexTypeDefinition)
+
+		val values = provider.getProposals(node).map [
+			replacementString
+		]
+		
+		assertEquals(1, values.filter[equals("required:")].size)
 	}
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/Proposal.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/Proposal.java
@@ -68,10 +68,9 @@ public class Proposal {
     public int hashCode() {
         final int prime = 31;
         int result = 1;
-        result = prime * result + ((description == null) ? 0 : description.hashCode());
         result = prime * result + ((displayString == null) ? 0 : displayString.hashCode());
         result = prime * result + ((replacementString == null) ? 0 : replacementString.hashCode());
-        result = prime * result + ((type == null) ? 0 : type.hashCode());
+
         return result;
     }
 
@@ -90,9 +89,7 @@ public class Proposal {
         Proposal other = (Proposal) obj;
 
         return Objects.equals(other.replacementString, replacementString) //
-                && Objects.equals(other.displayString, displayString) //
-                && Objects.equals(other.description, description) //
-                && Objects.equals(other.type, type);
+                && Objects.equals(other.displayString, displayString);
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerDocument.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerDocument.java
@@ -175,6 +175,11 @@ public class SwaggerDocument extends Document {
     }
 
     public Model getModel(int offset) {
+        // no parse errors
+        if (model != null) {
+            return model;
+        }
+
         try {
             if (0 > offset || offset > getLength()) {
                 return Model.parseYaml(schema, get());


### PR DESCRIPTION
This PR fixes the following issues relative to content assist
- #216 - Content-assist: strange description for the values of `format`
- #213 - Code-assist does not work for `in` for top-level parameters
- #214 - Code-assist: `required` show twice for path method parameters
