### PR TITLE
[#215] Code-assist: `file` as value for responses' `type`

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
@@ -170,18 +170,97 @@ class SwaggerContentAssistProcessorTest {
 	def void test3() {
 		val test = setUpContentAssistTest('''
 		 definitions:
+		  Foo:
+		    <1>
 		  Product:
-		    <1>required:
+		    <2>required:
 		      - name  
 		    properties:
 		      name:
 		        type: string
 		      description:
-		        type: <2>
+		        type: <3>
 		''', new SwaggerDocument)
-		
+
 		var proposals = test.apply(processor, "1")
+		var values = proposals.map[(it as StyledCompletionProposal).replacementString]
+		assertEquals(30, values.size)
+		assertThat(values, hasItems(
+			"$ref:", 
+			"format:", 
+			"title:", 
+			"description:", 
+			"multipleOf:", 
+			"maximum:", 
+			"exclusiveMaximum:", 
+			"minimum:", 
+			"exclusiveMinimum:", 
+			"maxLength:", 
+			"minLength:", 
+			"pattern:", 
+			"maxItems:", 
+			"minItems:", 
+			"uniqueItems:", 
+			"maxProperties:",
+			"minProperties:", 
+			"required:", 
+			"enum:", 
+			"additionalProperties:", 
+			"type:", 
+			"items:", 
+			"allOf:", 
+			"properties:", 
+			"discriminator:", 
+			"readOnly:", 
+			"xml:", 
+			"externalDocs:", 
+			"example:", 
+			"x-:"))
+
 		proposals = test.apply(processor, "2")
-//		println(proposals.map[(it as StyledCompletionProposal).replacementString])
+		values = proposals.map[(it as StyledCompletionProposal).replacementString]
+		// same without required and properties
+		assertEquals(28, values.size)
+		assertThat(values, hasItems(
+			"$ref:", 
+			"format:", 
+			"title:", 
+			"description:", 
+			"multipleOf:", 
+			"maximum:", 
+			"exclusiveMaximum:", 
+			"minimum:", 
+			"exclusiveMinimum:", 
+			"maxLength:", 
+			"minLength:", 
+			"pattern:", 
+			"maxItems:", 
+			"minItems:", 
+			"uniqueItems:", 
+			"maxProperties:",
+			"minProperties:",  
+			"enum:", 
+			"additionalProperties:", 
+			"type:", 
+			"items:", 
+			"allOf:",  
+			"discriminator:", 
+			"readOnly:", 
+			"xml:", 
+			"externalDocs:", 
+			"example:", 
+			"x-:"))
+		
+		proposals = test.apply(processor, "3")
+		values = proposals.map[(it as StyledCompletionProposal).replacementString]
+		assertEquals(7, values.size)
+		assertThat(values, hasItems(
+			"array",
+			"boolean",
+			"integer",
+			"null",
+			"number",
+			"object",
+			"string"))
 	}
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
@@ -258,7 +258,7 @@ class SwaggerContentAssistProcessorTest {
 			"array",
 			"boolean",
 			"integer",
-			"null",
+			"\"null\"",
 			"number",
 			"object",
 			"string"))

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerProposalProviderTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerProposalProviderTest.xtend
@@ -3,6 +3,7 @@ package com.reprezen.swagedit.assist
 import com.reprezen.swagedit.model.ArrayNode
 import com.reprezen.swagedit.model.ObjectNode
 import com.reprezen.swagedit.model.ValueNode
+import com.reprezen.swagedit.schema.JsonType
 import com.reprezen.swagedit.schema.MultipleTypeDefinition
 import com.reprezen.swagedit.schema.SwaggerSchema
 import com.reprezen.swagedit.tests.utils.PointerHelpers
@@ -11,7 +12,6 @@ import org.junit.Test
 
 import static org.hamcrest.core.IsCollectionContaining.*
 import static org.junit.Assert.*
-import com.reprezen.swagedit.schema.ComplexTypeDefinition
 
 class SwaggerProposalProviderTest {
 
@@ -203,18 +203,40 @@ class SwaggerProposalProviderTest {
 			"date"
 		))
 	}
-	
+
 	@Test
 	def void testGetParameterRequired() {
 		val node = new ObjectNode(null, "/parameters/foo".ptr)
 		node.type = schema.getType(node)
 
-		assertTrue(node.type instanceof ComplexTypeDefinition)
+		assertEquals(JsonType.ONE_OF, node.type.type)
 
 		val values = provider.getProposals(node).map [
 			replacementString
 		]
-		
+
 		assertEquals(1, values.filter[equals("required:")].size)
+	}
+
+	@Test
+	def void testGetResponsesType() {
+		val node = new ObjectNode(null, "/paths/~1foo/get/responses/200/schema/type".ptr)
+		node.type = schema.getType(node)
+
+		val values = provider.getProposals(node).map [
+			replacementString
+		]
+
+		assertEquals(8, values.size)
+		assertThat(values, hasItems(
+			"array",
+			"boolean",
+			"integer",
+			"null",
+			"number",
+			"object",
+			"string",
+			"file"
+		))
 	}
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerProposalProviderTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerProposalProviderTest.xtend
@@ -232,7 +232,7 @@ class SwaggerProposalProviderTest {
 			"array",
 			"boolean",
 			"integer",
-			"null",
+			"\"null\"",
 			"number",
 			"object",
 			"string",

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/editor/SwaggerDocumentTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/editor/SwaggerDocumentTest.xtend
@@ -192,7 +192,7 @@ class SwaggerDocumentTest {
 
 		test.apply("/paths/~1testing", "1")
 		test.apply("/paths/~1testing", "2")
-		test.apply("/paths/~1testing/get", "3")
+		test.apply("/paths/~1testing", "3")
 		test.apply("/paths/~1testing/get", "4")
 		test.apply("/paths/~1testing/get/parameters", "5")
 		test.apply("/paths/~1testing", "6")

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/schema/SwaggerSchemaTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/schema/SwaggerSchemaTest.xtend
@@ -1,6 +1,5 @@
 package com.reprezen.swagedit.schema
 
-import com.reprezen.swagedit.tests.utils.PointerHelpers
 import org.junit.Test
 
 import static org.hamcrest.core.IsCollectionContaining.*
@@ -8,9 +7,134 @@ import static org.junit.Assert.*
 
 class SwaggerSchemaTest {
 
-	extension PointerHelpers = new PointerHelpers
-
 	val schema = new SwaggerSchema
+
+	@Test
+	def void testGetCoreTypes() {
+		var type = schema.getType("http://json-schema.org/draft-04/schema#")
+		assertTrue(type instanceof ObjectTypeDefinition)
+		assertTrue(type.getType == JsonType.OBJECT)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/definitions/schemaArray")
+		assertTrue(type instanceof ArrayTypeDefinition)
+		assertTrue(type.getType == JsonType.ARRAY)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/definitions/positiveInteger")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.INTEGER)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/definitions/positiveIntegerDefault0")
+		assertTrue(type instanceof ComplexTypeDefinition)
+		assertTrue(type.getType == JsonType.ALL_OF)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/definitions/simpleTypes")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.ENUM)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/definitions/stringArray")
+		assertTrue(type instanceof ArrayTypeDefinition)
+		assertTrue(type.getType == JsonType.ARRAY)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/definitions/stringArray")
+		assertTrue(type instanceof ArrayTypeDefinition)
+		assertTrue(type.getType == JsonType.ARRAY)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/id")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.STRING)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/$schema")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.STRING)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/title")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.STRING)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/description")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.STRING)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/default")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.UNDEFINED)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/multipleOf")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.NUMBER)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/maximum")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.NUMBER)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/exclusiveMaximum")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.BOOLEAN)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/minimum")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.NUMBER)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/exclusiveMinimum")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.BOOLEAN)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/maxLength")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.INTEGER)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/minLength")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.ALL_OF)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/pattern")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.STRING)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/additionalItems")
+		assertTrue(type instanceof ComplexTypeDefinition)
+		assertTrue(type.getType == JsonType.ANY_OF)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/items")
+		assertTrue(type instanceof ComplexTypeDefinition)
+		assertTrue(type.getType == JsonType.ANY_OF)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/maxItems")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.INTEGER)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/minItems")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.ALL_OF)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/uniqueItems")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.BOOLEAN)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/maxProperties")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.INTEGER)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/minProperties")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.ALL_OF)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/required")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.ARRAY)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/additionalProperties")
+		assertTrue(type instanceof TypeDefinition)
+		assertTrue(type.getType == JsonType.ANY_OF)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/definitions")
+		assertTrue(type instanceof ObjectTypeDefinition)
+		assertTrue(type.getType == JsonType.OBJECT)
+
+		type = schema.getType("http://json-schema.org/draft-04/schema#/properties/definitions")
+		assertTrue(type instanceof ObjectTypeDefinition)
+		assertTrue(type.getType == JsonType.OBJECT)
+	}
 
 	@Test
 	def void testRootType() {
@@ -36,7 +160,7 @@ class SwaggerSchemaTest {
 
 	@Test
 	def void testInfoType() {
-		val infoType = schema.getType("/definitions/info".ptr)
+		val infoType = schema.getType("/definitions/info")
 		assertTrue(infoType instanceof ObjectTypeDefinition)
 
 		assertThat(
@@ -46,20 +170,39 @@ class SwaggerSchemaTest {
 
 		val titleType = infoType.getPropertyType("title")
 		assertTrue(titleType instanceof TypeDefinition)
-		assertEquals(schema.getType("/definitions/info/properties/title".ptr), titleType)
+		assertEquals(schema.getType("/definitions/info/properties/title"), titleType)
 	}
 
 	@Test
 	def void testPathType() {
-		val pathType = schema.getType("/definitions/paths".ptr)
+		val pathType = schema.getType("/definitions/paths")
 
 		assertTrue(pathType instanceof ObjectTypeDefinition)
 	}
 
 	@Test
 	def void testParameterType() {
-		val parametersType = schema.getType("/definitions/parametersList".ptr)
+		val parametersType = schema.getType("/definitions/parametersList")
 
 		assertTrue(parametersType instanceof ArrayTypeDefinition)
+	}
+
+	@Test
+	def void testParameterItems() {
+		val type = schema.getType("/definitions/parametersList/items")
+		assertTrue(type instanceof ComplexTypeDefinition)
+
+		val complexType = type as ComplexTypeDefinition
+		assertEquals(2, complexType.complexTypes.size)
+
+		val first = complexType.complexTypes.get(0)
+		assertTrue(first instanceof ReferenceTypeDefinition)
+
+		val first_resolved = (first as ReferenceTypeDefinition).resolve
+		assertTrue(first_resolved instanceof ComplexTypeDefinition)
+		assertEquals(2, (first_resolved as ComplexTypeDefinition).complexTypes.size)
+
+		val second = complexType.complexTypes.get(1)
+		assertTrue(second instanceof ReferenceTypeDefinition)
 	}
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/Proposal.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/Proposal.java
@@ -69,7 +69,6 @@ public class Proposal {
         final int prime = 31;
         int result = 1;
         result = prime * result + ((displayString == null) ? 0 : displayString.hashCode());
-        result = prime * result + ((replacementString == null) ? 0 : replacementString.hashCode());
 
         return result;
     }
@@ -88,8 +87,7 @@ public class Proposal {
 
         Proposal other = (Proposal) obj;
 
-        return Objects.equals(other.replacementString, replacementString) //
-                && Objects.equals(other.displayString, displayString);
+        return Objects.equals(other.displayString, displayString);
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessor.java
@@ -147,7 +147,7 @@ public class SwaggerContentAssistProcessor extends TemplateCompletionProcessor
             updateStatus();
             p = referenceProposalProvider.getProposals(currentPath, document.asJson(), cyclePosition);
         } else {
-            p = proposalProvider.getProposals(currentPath, model);
+            p = proposalProvider.getProposals(currentPath, model, prefix);
         }
 
         final Collection<ICompletionProposal> proposals = getCompletionProposals(p, prefix, documentOffset);

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerProposalProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerProposalProvider.java
@@ -114,6 +114,10 @@ public class SwaggerProposalProvider {
             return null;
         }
 
+        if (key == "null") {
+            key = "\"" + key + "\"";
+        }
+
         String labelType;
         if (Objects.equals(key, type.getContainingProperty())) {
             labelType = type.getType().getValue();
@@ -205,7 +209,7 @@ public class SwaggerProposalProvider {
             // if the type of array is string and
             // current value is a number, it should be put
             // into quotes to avoid validation issues
-            if (NumberUtils.isNumber(literal) && "string".equals(subType)) {
+            if ((NumberUtils.isNumber(literal) && "string".equals(subType)) || "null".equals(literal)) {
                 replStr = "\"" + literal + "\"";
             } else {
                 replStr = literal;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/model/Model.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/model/Model.java
@@ -122,14 +122,12 @@ public class Model {
         AbstractNode found = forLine(line);
         if (found != null) {
             found = findChildren(found, line, column);
-
             int c = found.getStart().getColumn();
-            if (column >= c) {
+            if (column > c || (column == c && found.getParent().isArray())) {
                 return found;
             } else {
                 return found.getParent();
             }
-
         } else {
             found = findBeforeLine(line, column);
             if (found != null) {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/ArrayTypeDefinition.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/ArrayTypeDefinition.java
@@ -12,7 +12,7 @@ package com.reprezen.swagedit.schema;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.swagedit.json.references.JsonReference;
+import com.reprezen.swagedit.schema.SwaggerSchema.JsonSchema;
 
 /**
  * Represents a JSON schema type definition for arrays.
@@ -38,24 +38,9 @@ public class ArrayTypeDefinition extends TypeDefinition {
 
     public final TypeDefinition itemsType;
 
-    public ArrayTypeDefinition(SwaggerSchema schema, JsonPointer pointer, JsonNode definition, JsonType type) {
-        super(schema, pointer, definition, type);
-
-        itemsType = TypeDefinition.create(schema, getItemsPointer());
-    }
-
-    private JsonPointer getItemsPointer() {
-        String p = getPointer().toString();
-
-        JsonNode node = content.get("items");
-
-        if (node.isObject() && node.has(JsonReference.PROPERTY)) {
-            p = node.get(JsonReference.PROPERTY).asText().substring(1);
-        } else {
-            p += "/items";
-        }
-
-        return JsonPointer.compile(p);
+    public ArrayTypeDefinition(JsonSchema schema, JsonPointer pointer, JsonNode definition) {
+        super(schema, pointer, definition, JsonType.ARRAY);
+        itemsType = schema.createType(this, "items", definition.get("items"));
     }
 
     @Override

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/JsonType.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/JsonType.java
@@ -59,6 +59,8 @@ public enum JsonType {
             return JsonType.OBJECT;
         } else if (node.has("anyOf")) {
             return JsonType.ANY_OF;
+        } else if (node.has("allOf")) {
+            return JsonType.ALL_OF;
         }
 
         return JsonType.UNDEFINED;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/MultipleTypeDefinition.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/MultipleTypeDefinition.java
@@ -12,6 +12,8 @@ package com.reprezen.swagedit.schema;
 
 import java.util.List;
 
+import com.reprezen.swagedit.schema.SwaggerSchema.JsonSchema;
+
 /**
  * Represents a JSON schema type definition that is defined in separated types.
  * 
@@ -20,7 +22,7 @@ public class MultipleTypeDefinition extends TypeDefinition {
 
     private final List<TypeDefinition> multipleTypes;
 
-    public MultipleTypeDefinition(SwaggerSchema schema, List<TypeDefinition> multipleTypes) {
+    public MultipleTypeDefinition(JsonSchema schema, List<TypeDefinition> multipleTypes) {
         super(schema, null, null, JsonType.UNDEFINED);
         this.multipleTypes = multipleTypes;
     }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/ReferenceTypeDefinition.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/ReferenceTypeDefinition.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.schema;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.swagedit.json.references.JsonReference;
+import com.reprezen.swagedit.schema.SwaggerSchema.JsonSchema;
+
+/**
+ * Represents a JSON reference that should be resolved as a type definition.
+ *
+ */
+public class ReferenceTypeDefinition extends TypeDefinition {
+
+    private TypeDefinition resolved;
+
+    public ReferenceTypeDefinition(JsonSchema schema, JsonPointer pointer, JsonNode definition) {
+        super(schema, pointer, definition, JsonType.UNDEFINED);
+    }
+
+    public TypeDefinition resolve() {
+        if (resolved != null) {
+            return resolved;
+        }
+        return resolved = schema.getManager().resolve(this, content.get(JsonReference.PROPERTY).asText());
+    }
+
+    @Override
+    public JsonType getType() {
+        return resolve().getType();
+    }
+
+    @Override
+    public String getDescription() {
+        return resolve().getDescription();
+    }
+
+    @Override
+    public JsonPointer getPointer() {
+        return resolve().getPointer();
+    }
+
+    @Override
+    public JsonNode asJson() {
+        return resolve().asJson();
+    }
+
+    @Override
+    public String getContainingProperty() {
+        return resolve().getContainingProperty();
+    }
+
+    @Override
+    public TypeDefinition getPropertyType(String property) {
+        return resolve().getPropertyType(property);
+    }
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/SwaggerSchema.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/SwaggerSchema.java
@@ -17,6 +17,8 @@ import java.util.Map;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Strings;
+import com.reprezen.swagedit.json.references.JsonReference;
 import com.reprezen.swagedit.model.AbstractNode;
 
 /**
@@ -26,31 +28,121 @@ import com.reprezen.swagedit.model.AbstractNode;
 public class SwaggerSchema {
 
     private final ObjectMapper mapper = new ObjectMapper();
+    private final Map<String, JsonSchema> schemas = new HashMap<>();
 
-    // private JsonNode core;
-    private JsonNode content;
-
-    private TypeDefinition rootType;
-    private final Map<JsonPointer, TypeDefinition> types = new HashMap<>();
+    private JsonSchema swaggerType;
+    private JsonSchema coreType;
 
     public SwaggerSchema() {
         init();
     }
 
-    protected void init() {
-        // try {
-        // core = mapper.readTree(getClass().getResourceAsStream("core.json"));
-        // } catch (IOException e) {
-        // return;
-        // }
+    protected class JsonSchema {
 
+        private final Map<JsonPointer, TypeDefinition> types = new HashMap<>();
+        private final String id;
+        private final JsonNode content;
+        private final SwaggerSchema manager;
+
+        private ObjectTypeDefinition type;
+
+        public JsonSchema(JsonNode content, SwaggerSchema manager) {
+            this.id = content.get("id").asText().replaceAll("#", "");
+            this.content = content;
+            this.manager = manager;
+            this.manager.schemas.put(id, this);
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public SwaggerSchema getManager() {
+            return manager;
+        }
+
+        void setType(ObjectTypeDefinition type) {
+            this.type = type;
+        }
+
+        public ObjectTypeDefinition getType() {
+            return type;
+        }
+
+        /**
+         * Creates a new type after resolving it from the pointer.
+         * 
+         * @param pointer
+         * @return type
+         */
+        protected TypeDefinition createType(JsonPointer pointer) {
+            final JsonNode definition = content.at(pointer);
+            if (definition == null || definition.isMissingNode()) {
+                return null;
+            }
+
+            TypeDefinition typeDef;
+            if (JsonReference.isReference(definition)) {
+                typeDef = new ReferenceTypeDefinition(this, pointer, definition);
+            } else {
+                final JsonType type = JsonType.valueOf(definition);
+                switch (type) {
+                case OBJECT:
+                    typeDef = new ObjectTypeDefinition(this, pointer, definition);
+                    break;
+                case ARRAY:
+                    typeDef = new ArrayTypeDefinition(this, pointer, definition);
+                    break;
+                case ALL_OF:
+                case ANY_OF:
+                case ONE_OF:
+                    typeDef = new ComplexTypeDefinition(this, pointer, definition, type);
+                    break;
+                default:
+                    typeDef = new TypeDefinition(this, pointer, definition, type);
+                }
+            }
+            types.put(pointer, typeDef);
+            return typeDef;
+        }
+
+        protected TypeDefinition createType(TypeDefinition parent, String property, JsonNode definition) {
+            return createType(JsonPointer.compile(parent.getPointer() + "/" + property));
+        }
+
+        public JsonNode resolve(JsonPointer pointer) {
+            return content.at(pointer);
+        }
+
+        public TypeDefinition get(JsonPointer pointer) {
+            if (pointer == null || Strings.emptyToNull(pointer.toString()) == null) {
+                return type;
+            }
+            return types.get(pointer);
+        }
+
+    }
+
+    protected void init() {
+        JsonNode core;
+        try {
+            core = mapper.readTree(getClass().getResourceAsStream("core.json"));
+        } catch (IOException e) {
+            return;
+        }
+
+        JsonNode content;
         try {
             content = mapper.readTree(getClass().getResourceAsStream("schema.json"));
         } catch (IOException e) {
             return;
         }
 
-        rootType = TypeDefinition.create(this, JsonPointer.compile(""));
+        coreType = new JsonSchema(core, this);
+        coreType.setType(new ObjectTypeDefinition(coreType, JsonPointer.compile(""), core));
+
+        swaggerType = new JsonSchema(content, this);
+        swaggerType.setType(new ObjectTypeDefinition(swaggerType, JsonPointer.compile(""), content));
     }
 
     /**
@@ -59,7 +151,7 @@ public class SwaggerSchema {
      * @return schema content
      */
     public JsonNode asJson() {
-        return content;
+        return swaggerType.getType().asJson();
     }
 
     /**
@@ -76,11 +168,11 @@ public class SwaggerSchema {
         JsonPointer pointer = node.getPointer();
 
         if (JsonPointer.compile("").equals(pointer)) {
-            return rootType;
+            return swaggerType.getType();
         }
 
         String[] paths = pointer.toString().substring(1).split("/");
-        TypeDefinition current = rootType;
+        TypeDefinition current = swaggerType.getType();
 
         if (current != null) {
             for (String property : paths) {
@@ -102,7 +194,7 @@ public class SwaggerSchema {
      * @return root type
      */
     public TypeDefinition getRootType() {
-        return rootType;
+        return swaggerType.getType();
     }
 
     /**
@@ -113,18 +205,63 @@ public class SwaggerSchema {
      * - /definitions/paths
      * 
      * @param pointer
-     * @return
+     * @return type
      */
-    public TypeDefinition getType(JsonPointer pointer) {
-        return types.get(pointer);
-    }
+    public TypeDefinition getType(String reference) {
+        if (Strings.emptyToNull(reference) == null) {
+            return swaggerType.getType();
+        }
 
-    public void add(TypeDefinition typeDef) {
-        types.put(typeDef.getPointer(), typeDef);
+        JsonPointer pointer = pointer(reference);
+        JsonSchema schema = getSchema(baseURI(reference));
+
+        return schema.get(pointer);
     }
 
     public ObjectMapper getMapper() {
         return mapper;
+    }
+
+    /**
+     * Returns the type definition reachable by the JSON reference. The context type is used to identify the schema that
+     * will be used to resolve the referenced type.
+     * 
+     * @param context
+     * @param reference
+     * @return type
+     */
+    public TypeDefinition resolve(TypeDefinition context, String reference) {
+        String schemaId = baseURI(reference);
+        JsonPointer pointer = pointer(reference);
+        JsonSchema schema = schemaId == null ? context.getSchema() : getSchema(schemaId);
+
+        if (pointer == null) {
+            return schema.getType();
+        }
+        return schema.get(pointer);
+    }
+
+    protected JsonSchema getSchema(String id) {
+        return Strings.emptyToNull(id) == null ? swaggerType : schemas.get(id);
+    }
+
+    protected String baseURI(String href) {
+        if (Strings.emptyToNull(href) == null || href.startsWith("/")) {
+            return null;
+        }
+
+        return href.startsWith("#") ? null : href.split("#")[0];
+    }
+
+    protected JsonPointer pointer(String href) {
+        if (href.startsWith("#")) {
+            return JsonPointer.compile(href.substring(1));
+        } else if (href.startsWith("/")) {
+            return JsonPointer.compile(href);
+        } else {
+            String[] split = href.split("#");
+            return split.length > 1 ? JsonPointer.compile(split[1]) : null;
+        }
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/TypeDefinition.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/TypeDefinition.java
@@ -12,6 +12,7 @@ package com.reprezen.swagedit.schema;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.reprezen.swagedit.schema.SwaggerSchema.JsonSchema;
 
 /**
  * Represents a type defined inside a JSON Schema.
@@ -19,18 +20,16 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public class TypeDefinition {
 
-    protected final SwaggerSchema schema;
+    protected final JsonSchema schema;
     protected final JsonNode content;
     protected final JsonPointer pointer;
     protected final JsonType type;
 
-    public TypeDefinition(SwaggerSchema schema, JsonPointer pointer, JsonNode definition, JsonType type) {
+    public TypeDefinition(JsonSchema schema, JsonPointer pointer, JsonNode definition, JsonType type) {
         this.schema = schema;
         this.content = definition;
         this.pointer = pointer;
         this.type = type;
-
-        schema.add(this);
     }
 
     public JsonType getType() {
@@ -41,7 +40,7 @@ public class TypeDefinition {
         return content;
     }
 
-    public SwaggerSchema getSchema() {
+    public JsonSchema getSchema() {
         return schema;
     }
 
@@ -65,56 +64,15 @@ public class TypeDefinition {
         if (content == null) {
             return null;
         }
-
         if (!content.has("description")) {
             return null;
         }
-
         return content.get("description").asText();
     }
 
     @Override
     public String toString() {
-        return content.toString();
-    }
-
-    /**
-     * Returns the type reachable by the given pointer inside the given schema.
-     * 
-     * @param schema
-     * @param pointer
-     * @return type
-     */
-    public static TypeDefinition create(SwaggerSchema schema, JsonPointer pointer) {
-        if (schema.getType(pointer) != null) {
-            return schema.getType(pointer);
-        }
-
-        final JsonNode definition = schema.asJson().at(pointer);
-        if (definition == null || definition.isMissingNode()) {
-            return null;
-        }
-
-        final JsonType type = JsonType.valueOf(definition);
-
-        TypeDefinition typeDef;
-        switch (type) {
-        case OBJECT:
-            typeDef = new ObjectTypeDefinition(schema, pointer, definition, type);
-            break;
-        case ARRAY:
-            typeDef = new ArrayTypeDefinition(schema, pointer, definition, type);
-            break;
-        case ALL_OF:
-        case ANY_OF:
-        case ONE_OF:
-            typeDef = new ComplexTypeDefinition(schema, pointer, definition, type);
-            break;
-        default:
-            typeDef = new TypeDefinition(schema, pointer, definition, type);
-        }
-
-        return typeDef;
+        return "( " + type + " " + content.toString() + " )";
     }
 
     protected static String getProperty(JsonPointer pointer) {


### PR DESCRIPTION
This commit adds support for the core json schema, and resolves the issue with missing content assist information that is available only from that core schema. See #215 
