### PR TITLE
#123 Array without items is disallowed by Swagger, should be shown as a validation error

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
@@ -468,4 +468,54 @@ class ValidatorTest {
 
 	}
 
+	@Test
+	def void testArrayWithItemsAreValid() {
+		val content = '''
+		swagger: '2.0'
+		info:
+		  version: 0.0.0
+		  title: Simple API
+		paths:
+		  /foo/{bar}:
+		    get:
+		      responses:
+		        '200':
+		          description: OK
+		definitions:
+		  Pets:
+		    type: array
+		    items: 
+		      type: string
+		'''
+
+		document.set(content)
+		document.onChange()
+		val errors = validator.validate(document, null)
+		assertEquals(0, errors.size())
+	}
+
+	@Test
+	def void testArrayWithMissingItemsAreNotValid() {
+		val content = '''
+		swagger: '2.0'
+		info:
+		  version: 0.0.0
+		  title: Simple API
+		paths:
+		  /foo/{bar}:
+		    get:
+		      responses:
+		        '200':
+		          description: OK
+		definitions:
+		  Pets:
+		    type: array
+		'''
+
+		document.set(content)
+		document.onChange()
+		val errors = validator.validate(document, null)
+		assertEquals(1, errors.size())
+		assertEquals(Messages.error_array_missing_items, errors.get(0).message)
+	}
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
@@ -32,6 +32,7 @@ public class Messages extends NLS {
     public static String error_cannot_read_content;
     public static String error_missing_reference;
     public static String error_invalid_reference;
+    public static String error_array_missing_items;
 
     static {
         NLS.initializeMessages(BUNDLE_NAME, Messages.class);

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
@@ -25,6 +25,7 @@ error_missing_reference=Invalid Reference - SwagEdit was unable to resolve the r
 The value must be a valid JSON Reference (for external references) or JSON Pointer (for local references), and must resolve to an object of the expected type.
 error_invalid_reference=Invalid Reference Syntax - The referenced path or URI may contain invalid characters.  \n\
 The value must be a valid JSON Reference (for external references) or JSON Pointer (for local references), and must resolve to an object of the expected type.
+error_array_missing_items=Invalid array definition, items type should be present  
 content_assist_proposal_local = Press '%s' to show %s in the current file.
 content_assist_proposal_project = Press '%s' to show all %s in the project.
 content_assist_proposal_workspace = Press '%s' to show all %s in the workspace.

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
@@ -135,7 +135,7 @@ public class Validator {
                         ValueNode typeValue = n.get("type").asValue();
                         if ("array".equalsIgnoreCase(typeValue.getValue().toString())) {
                             if (n.get("items") == null) {
-                                errors.add(new SwaggerError(n.getStart().getLine(), IMarker.SEVERITY_ERROR,
+                                errors.add(new SwaggerError(n.getStart().getLine() + 1, IMarker.SEVERITY_ERROR,
                                         Messages.error_array_missing_items));
                             }
                         }


### PR DESCRIPTION
Add validation error when array type is missing items definition, see #123 
