### PR TITLE
[#123] Array without items is disallowed by Swagger, should be shown …

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
@@ -510,12 +510,20 @@ class ValidatorTest {
 		definitions:
 		  Pets:
 		    type: array
+		  Foo:
+		    type: object
+		    properties:
+		      bar:
+		        type: array
 		'''
 
 		document.set(content)
 		document.onChange()
 		val errors = validator.validate(document, null)
-		assertEquals(1, errors.size())
+		assertEquals(2, errors.size())
 		assertEquals(Messages.error_array_missing_items, errors.get(0).message)
+		assertEquals(12, errors.get(0).line)
+		assertEquals(Messages.error_array_missing_items, errors.get(1).message)
+		assertEquals(17, errors.get(1).line)
 	}
 }


### PR DESCRIPTION
…as a validation error, 

for issue #123 

Previous PR only implement validation for top level elements under `definitions`. This PR makes validation possible for all schema definitions of type array.
