### PR TITLE
ZEN-2180 - customize SwagEdit default font size

### DIFF
--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -210,9 +210,9 @@
         <themeElementCategory label="SwagEdit" id="com.reprezen.swagedit.editor.presentation"/>
         <fontDefinition
               categoryId="com.reprezen.swagedit.editor.presentation"
+              defaultsTo="org.eclipse.jface.textfont"
               id="com.reprezen.swagedit.editor.textfont"
-              label="SwagEdit Text Font"
-              value="Arial-regular-12">
+              label="SwagEdit Text Font">
          <description>
             This font is used by Swagger editor.
          </description>

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -25,7 +25,8 @@
             default="false"
             icon="icons/swagger_16.png"
             id="com.reprezen.swagedit.editor"
-            name="%editor.name">
+            name="%editor.name"
+            symbolicFontName="com.reprezen.swagedit.editor.textfont">
          <contentTypeBinding
                contentTypeId="com.reprezen.swagedit.contenttype.swagger.yaml">
          </contentTypeBinding>
@@ -203,5 +204,19 @@
             commandId="com.reprezen.swagedit.commands.quickoutline">
       </handler>
    </extension>
-
+   
+   <extension
+         point="org.eclipse.ui.themes">
+        <themeElementCategory label="SwagEdit" id="com.reprezen.swagedit.editor.presentation"/>
+        <fontDefinition
+              categoryId="com.reprezen.swagedit.editor.presentation"
+              id="com.reprezen.swagedit.editor.textfont"
+              label="SwagEdit Text Font"
+              value="Arial-regular-12">
+         <description>
+            This font is used by Swagger editor.
+         </description>
+        </fontDefinition>
+   </extension>
+   
 </plugin>


### PR DESCRIPTION
@daffinm , you asked me to provide a way to customize SwagEdit default font size which should not influence other editors. I added a SwagEdit font theme, it's available both in RCP and add-on modes:
<img width="706" alt="screen shot 2016-11-02 at 4 21 33 pm" src="https://cloud.githubusercontent.com/assets/644582/19946105/5f0bdce8-a119-11e6-95dd-d460887159b3.png">
It applies Arial-regular-12 to Swagger editors by default. The default value can be changes in preferences.
I did not find Consolas in my installation and replaced it with Arial. Please let me know if you have better suggestions.

Before this change:
<img width="669" alt="swagedit_oldfont" src="https://cloud.githubusercontent.com/assets/644582/19946150/8a7a7efc-a119-11e6-9859-ab66fb7b9396.png">

With this change:
<img width="675" alt="swagedit_newfont" src="https://cloud.githubusercontent.com/assets/644582/19946155/8f92dc5e-a119-11e6-9582-821f6ce97979.png">

