### PR TITLE
[#239] Swagger Spec pasted into editor shows spurious warnings until …

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
@@ -45,7 +45,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/definitions/Valid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
 
 		assertEquals(0, errors.size())
 	}
@@ -70,7 +70,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/definitions/Invalid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -98,7 +98,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/paths/~1foo~1{bar}")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
 
 		assertEquals(0, errors.size())
 	}
@@ -123,7 +123,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/paths/~1foo~1{bar}")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(new SwaggerError(9, IMarker.SEVERITY_WARNING, Messages.error_invalid_reference)))
@@ -149,7 +149,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/paths/~1foo")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -181,7 +181,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
 
 		assertEquals(0, errors.size())
 	}
@@ -206,7 +206,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml")
-		val errors = validator(#{otherURI -> null}).validate(baseURI, document.model)
+		val errors = validator(#{otherURI -> null}).validate(baseURI, document)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -241,7 +241,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml#/info/version")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
 
 		assertEquals(0, errors.size())
 	}
@@ -273,7 +273,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml#/info/foo")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -300,7 +300,7 @@ class ReferenceValidatorTest {
 
 		document.set(content)
 		val baseURI = new URI(null, null, null)
-		val errors = validator(#{}).validate(baseURI, document.model)
+		val errors = validator(#{}).validate(baseURI, document)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -331,7 +331,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/definitions/Valid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document.model)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
 
 		assertEquals(1, errors.size())
 		assertEquals(Messages.warning_simple_reference, errors.get(0).message)

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetector.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/hyperlinks/JsonReferenceHyperlinkDetector.java
@@ -48,7 +48,7 @@ public class JsonReferenceHyperlinkDetector extends AbstractSwaggerHyperlinkDete
             reference = getFactory().create(node);
         }
 
-        if (reference.isInvalid() || reference.isMissing(getBaseURI())) {
+        if (reference.isInvalid() || reference.isMissing(doc, getBaseURI())) {
             return null;
         }
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonDocumentManager.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonDocumentManager.java
@@ -91,6 +91,11 @@ public class JsonDocumentManager {
     }
 
     public JsonNode getDocument(URI uri) {
+        final IFile file = getFile(uri);
+        if (file == null || !file.exists()) {
+            return null;
+        }
+
         try {
             return getDocument(uri.toURL());
         } catch (MalformedURLException e) {
@@ -106,7 +111,7 @@ public class JsonDocumentManager {
      * @return file
      */
     public IFile getFile(URI uri) {
-        return DocumentUtils.getWorkspaceFile(uri);
+        return uri != null ? DocumentUtils.getWorkspaceFile(uri) : null;
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReferenceValidator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/json/references/JsonReferenceValidator.java
@@ -19,8 +19,8 @@ import java.util.Set;
 
 import com.google.common.collect.Sets;
 import com.reprezen.swagedit.Messages;
+import com.reprezen.swagedit.editor.SwaggerDocument;
 import com.reprezen.swagedit.model.AbstractNode;
-import com.reprezen.swagedit.model.Model;
 import com.reprezen.swagedit.validation.SwaggerError;
 
 /**
@@ -35,24 +35,25 @@ public class JsonReferenceValidator {
     }
 
     /**
-     * Returns a collection containing all errors being invalid JSON references present in the JSON document.
+     * Returns a collection containing all errors being invalid JSON references present in the Swagger document.
      * 
      * @param baseURI
-     * @param model
+     * @param document
      * @return collection of errors
      */
-    public Collection<? extends SwaggerError> validate(URI baseURI, Model model) {
-        return doValidate(baseURI, collector.collect(baseURI, model));
+    public Collection<? extends SwaggerError> validate(URI baseURI, SwaggerDocument doc) {
+        return doValidate(baseURI, doc, collector.collect(baseURI, doc.getModel()));
     }
 
-    protected Collection<? extends SwaggerError> doValidate(URI baseURI, Iterable<JsonReference> references) {
+    protected Collection<? extends SwaggerError> doValidate(URI baseURI, SwaggerDocument doc,
+            Iterable<JsonReference> references) {
         Set<SwaggerError> errors = Sets.newHashSet();
         for (JsonReference reference : references) {
             if (reference instanceof JsonReference.SimpleReference) {
                 errors.add(createReferenceError(SEVERITY_WARNING, Messages.warning_simple_reference, reference));
             } else if (reference.isInvalid()) {
                 errors.add(createReferenceError(SEVERITY_ERROR, Messages.error_invalid_reference, reference));
-            } else if (reference.isMissing(baseURI)) {
+            } else if (reference.isMissing(doc, baseURI)) {
                 errors.add(createReferenceError(SEVERITY_WARNING, Messages.error_missing_reference, reference));
             } else if (reference.containsWarning()) {
                 errors.add(createReferenceError(SEVERITY_WARNING, Messages.error_invalid_reference, reference));

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
@@ -96,7 +96,7 @@ public class Validator {
                 errors.addAll(validateAgainstSchema(new ErrorProcessor(yaml), document));
                 errors.addAll(validateModel(document.getModel()));
                 errors.addAll(checkDuplicateKeys(yaml));
-                errors.addAll(referenceValidator.validate(baseURI, document.getModel()));
+                errors.addAll(referenceValidator.validate(baseURI, document));
             }
         }
 


### PR DESCRIPTION
…saved

Resolution of JSON references will be done, if references are locals, by inspecting the content of the current documents and not by loading the content of the file on disk. This will ensure that validation of references will be correct when new content is copy/paste inside the current editor.

See issue #239 