### PR TITLE
[#116] SwagEdit does not detect some validation errors in some array …

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
@@ -642,4 +642,33 @@ class ValidatorTest {
 		assertEquals(Messages.error_type_missing, errors.get(0).message)
 	}
 
+	@Test
+	def void testArrayWithItemsIsInvalid() {
+		val content = '''
+		swagger: '2.0'
+		info:
+		  version: 0.0.0
+		  title: Simple API
+		paths:
+		  /foo/{bar}:
+		    get:
+		      responses:
+		        '200':
+		          description: OK
+		definitions:
+		  Pets:
+		    type: array
+		    items:
+		      - type: string		 
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null)		
+		assertEquals(1, errors.size())
+		assertTrue(errors.map[message].forall[it.equals(Messages.error_array_items_should_be_object)])
+		assertThat(errors.map[line], hasItems(14))
+	}
+
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
@@ -35,6 +35,8 @@ public class Messages extends NLS {
     public static String error_cannot_read_content;
     public static String error_missing_reference;
     public static String error_invalid_reference;
+    public static String error_array_items_should_be_object;
+
     public static String error_array_missing_items;
     public static String error_type_missing;
     public static String error_wrong_type;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
@@ -26,6 +26,7 @@ The value must be a valid JSON Reference (for external references) or JSON Point
 error_invalid_reference= Invalid Reference Syntax - The referenced path or URI may contain invalid characters.  \n\
 The value must be a valid JSON Reference (for external references) or JSON Pointer (for local references), and must resolve to an object of the expected type.
 error_array_missing_items=Invalid array definition, items type should be present
+error_array_items_should_be_object=Invalid array definition, items should be an object 
 error_type_missing = Invalid definition, type is missing
 error_wrong_type = Invalid type, should be object
 error_missing_properties = Invalid type definition, object has a required field but is missing a properties field

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
@@ -144,7 +144,7 @@ public class Validator {
 
         if (model != null && model.getRoot() != null) {
             for (AbstractNode node : model.allNodes()) {
-                checkMissingItemsKeyInArrayType(errors, node);
+                checkArrayTypeDefinition(errors, node);
                 checkObjectTypeDefinition(errors, node);
             }
         }
@@ -157,10 +157,15 @@ public class Validator {
      * @param errors
      * @param model
      */
-    protected void checkMissingItemsKeyInArrayType(Set<SwaggerError> errors, AbstractNode node) {
+    protected void checkArrayTypeDefinition(Set<SwaggerError> errors, AbstractNode node) {
         if (hasArrayType(node)) {
-            if (node.get("items") == null) {
+            AbstractNode items = node.get("items");
+            if (items == null) {
                 errors.add(error(node, IMarker.SEVERITY_ERROR, Messages.error_array_missing_items));
+            } else {
+                if (!items.isObject()) {
+                    errors.add(error(items, IMarker.SEVERITY_ERROR, Messages.error_array_items_should_be_object));
+                }
             }
         }
     }


### PR DESCRIPTION
…schemas

Add validation for array items. See issue #116 

This PR adds validation for array items, see tests https://github.com/RepreZen/SwagEdit/commit/feb0a91889672bf0de439ad3754cc72324d71071#diff-bab1306f3a15280d552d52440a4d0ef1R646 

This will add the error message `Invalid array definition, items should be an object ` if the items is not an object (as define here https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#user-content-parameterItems)