### PR TITLE
Fix code template for schema definition

### DIFF
--- a/com.reprezen.swagedit/resources/templates.xml
+++ b/com.reprezen.swagedit/resources/templates.xml
@@ -295,7 +295,8 @@ schema:
        id="com.reprezen.swagedit.templates.schema" 
        description="schema template" 
        context="com.reprezen.swagedit.templates.swagger.schema" 
-       enabled="true">required:
+       enabled="true">type: object
+required:
   - ${name}  
 properties:
   ${name}:


### PR DESCRIPTION
It did not define a `type` which was recently made mandatory. Thus,
created schema was generating a validation error