### PR TITLE
ZEN-3178 - expose JsonPointer as a String to prevent LinkageError

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/model/AbstractNode.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/model/AbstractNode.java
@@ -105,6 +105,14 @@ public abstract class AbstractNode {
     public JsonPointer getPointer() {
         return pointer;
     }
+    
+    /**
+     * 
+     * @return JSON pointer as a string
+     */
+    public String getPointerString() {
+        return getPointer().toString();
+    }
 
     public void setType(TypeDefinition type) {
         this.type = type;


### PR DESCRIPTION
Calling #getPointer().toString() from outside of this plugin causes an
error:
java.lang.LinkageError: loader constraint violation: loader (instance of
org/eclipse/osgi/internal/loader/EquinoxClassLoader) previously
initiated loading for a different type with name
"com/fasterxml/jackson/core/JsonPointer" 

It happens because SwagEdit uses Jackson shipped as a lib jar. We should
replace lib/jar for Jackson by an instance from Orbit repository, but
using a JsonPointer as a string for now.

@andylowry , I am merging this PR because I need these changes for compilation, but I encourage you to review it when you have a moment.

Also see task/jackson_orbit