### PR TITLE
Eliminate LinkageError when passing a JsonPointer loaded by a different plugin

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/model/Model.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/model/Model.java
@@ -200,6 +200,10 @@ public class Model {
         return nodes.get(pointer);
     }
 
+    public AbstractNode find(String pointer) {
+        return nodes.get(JsonPointer.valueOf(pointer));
+    }
+    
     private AbstractNode add(AbstractNode node) {
         if (node != null && node.getPointer() != null) {
             nodes.put(node.getPointer(), node);


### PR DESCRIPTION
Also see PR #255

Because Jackson is shipped as a lib jar, external plugin fail to call
Model#find(JsonPointer):
 
```
java.lang.LinkageError: loader constraint violation: when resolving
method
"com.reprezen.swagedit.model.Model.find(Lcom/fasterxml/jackson/core/JsonPointer;)Lcom/reprezen/swagedit/model/AbstractNode;"
the class loader (instance of
org/eclipse/osgi/internal/loader/EquinoxClassLoader) of the current
class, and the class loader (instance of
org/eclipse/osgi/internal/loader/EquinoxClassLoader) for the method's
defining class, com/reprezen/swagedit/model/Model, have different Class
objects for the type com/fasterxml/jackson/core/JsonPointer used in the
signature
```