### PR TITLE
#257 Support JSON References in contexts not allowed by Swagger 2.0

### DIFF
--- a/com.reprezen.swagedit/OSGI-INF/l10n/bundle.properties
+++ b/com.reprezen.swagedit/OSGI-INF/l10n/bundle.properties
@@ -6,4 +6,5 @@ content-type.name = Swagger Content Type
 preferences.page.name = SwagEdit
 preferences.page.colors.name = Color Preferences
 preferences.page.templates.name = Templates
+preferences.page.validation.name = Validation
 Bundle-Name = SwagEdit

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -67,6 +67,12 @@
             id="com.reprezen.swagedit.preferences.SwaggerTemplatePreferences"
             name="%preferences.page.templates.name">
       </page>
+      <page
+            category="com.reprezen.swagedit.preferences"
+            class="com.reprezen.swagedit.preferences.SwaggerValidationPreferences"
+            id="com.reprezen.swagedit.preferences.SwaggerValidationPreferences"
+            name="%preferences.page.validation.name">
+      </page>
    </extension>
 
    <extension

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/Activator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/Activator.java
@@ -10,12 +10,16 @@
  *******************************************************************************/
 package com.reprezen.swagedit;
 
+import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.ALL_VALIDATION_PREFS;
+
 import java.io.IOException;
 
 import org.dadacoalition.yedit.YEditLog;
 import org.eclipse.core.runtime.FileLocator;
+import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Path;
 import org.eclipse.core.runtime.Platform;
+import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.resource.ImageDescriptor;
 import org.eclipse.jface.text.templates.ContextTypeRegistry;
 import org.eclipse.jface.text.templates.persistence.TemplateStore;
@@ -146,8 +150,14 @@ public class Activator extends AbstractUIPlugin {
     public SwaggerSchema getSchema() {
         if (schema == null) {
             schema = new SwaggerSchema();
+            for (String prefKey : ALL_VALIDATION_PREFS) {
+                try {
+                    schema.allowJsonRefInContext(prefKey, (boolean) getPreferenceStore().getBoolean(prefKey));
+                } catch (Exception e) {
+                    getLog().log(new Status(IStatus.ERROR, Activator.PLUGIN_ID, e.getMessage(), e));
+                }
+            }
         }
-
         return schema;
     }
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.reprezen.swagedit.editor;
 
+import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.ALL_VALIDATION_PREFS;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -121,71 +123,77 @@ public class SwaggerEditor extends YEdit implements IShowInSource, IShowInTarget
 
     /*
      * This listener is added to the preference store when the editor is initialized. It listens to changes to color
-     * preferences. Once a color change happens, the editor is re-initialize.
+     * preferences. Once a color change happens, the editor is re-initialized.
+     * It also handles changes in validation preferences
      */
     private final IPropertyChangeListener preferenceChangeListener = new IPropertyChangeListener() {
 
-        private final List<String> preferenceKeys = new ArrayList<>();
+        private final List<String> colorPreferenceKeys = new ArrayList<>();
         {
-            preferenceKeys.add(PreferenceConstants.COLOR_COMMENT);
-            preferenceKeys.add(PreferenceConstants.BOLD_COMMENT);
-            preferenceKeys.add(PreferenceConstants.ITALIC_COMMENT);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_COMMENT);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_COMMENT);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_COMMENT);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_COMMENT);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_COMMENT);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_KEY);
-            preferenceKeys.add(PreferenceConstants.BOLD_KEY);
-            preferenceKeys.add(PreferenceConstants.ITALIC_KEY);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_KEY);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_KEY);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_KEY);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_KEY);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_KEY);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_SCALAR);
-            preferenceKeys.add(PreferenceConstants.BOLD_SCALAR);
-            preferenceKeys.add(PreferenceConstants.ITALIC_SCALAR);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_SCALAR);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_SCALAR);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_SCALAR);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_SCALAR);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_SCALAR);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_DEFAULT);
-            preferenceKeys.add(PreferenceConstants.BOLD_DEFAULT);
-            preferenceKeys.add(PreferenceConstants.ITALIC_DEFAULT);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_DEFAULT);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_DEFAULT);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_DEFAULT);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_DEFAULT);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_DEFAULT);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_DOCUMENT);
-            preferenceKeys.add(PreferenceConstants.BOLD_DOCUMENT);
-            preferenceKeys.add(PreferenceConstants.ITALIC_DOCUMENT);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_DOCUMENT);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_DOCUMENT);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_DOCUMENT);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_DOCUMENT);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_DOCUMENT);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_ANCHOR);
-            preferenceKeys.add(PreferenceConstants.BOLD_ANCHOR);
-            preferenceKeys.add(PreferenceConstants.ITALIC_ANCHOR);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_ANCHOR);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_ANCHOR);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_ANCHOR);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_ANCHOR);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_ANCHOR);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_ALIAS);
-            preferenceKeys.add(PreferenceConstants.BOLD_ALIAS);
-            preferenceKeys.add(PreferenceConstants.ITALIC_ALIAS);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_ALIAS);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_ALIAS);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_ALIAS);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_ALIAS);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_ALIAS);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_TAG_PROPERTY);
-            preferenceKeys.add(PreferenceConstants.BOLD_TAG_PROPERTY);
-            preferenceKeys.add(PreferenceConstants.ITALIC_TAG_PROPERTY);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_TAG_PROPERTY);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_TAG_PROPERTY);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_TAG_PROPERTY);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_TAG_PROPERTY);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_TAG_PROPERTY);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_INDICATOR_CHARACTER);
-            preferenceKeys.add(PreferenceConstants.BOLD_INDICATOR_CHARACTER);
-            preferenceKeys.add(PreferenceConstants.ITALIC_INDICATOR_CHARACTER);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_INDICATOR_CHARACTER);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_INDICATOR_CHARACTER);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_INDICATOR_CHARACTER);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_INDICATOR_CHARACTER);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_INDICATOR_CHARACTER);
 
-            preferenceKeys.add(PreferenceConstants.COLOR_CONSTANT);
-            preferenceKeys.add(PreferenceConstants.BOLD_CONSTANT);
-            preferenceKeys.add(PreferenceConstants.ITALIC_CONSTANT);
-            preferenceKeys.add(PreferenceConstants.UNDERLINE_CONSTANT);
+            colorPreferenceKeys.add(PreferenceConstants.COLOR_CONSTANT);
+            colorPreferenceKeys.add(PreferenceConstants.BOLD_CONSTANT);
+            colorPreferenceKeys.add(PreferenceConstants.ITALIC_CONSTANT);
+            colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_CONSTANT);
         }
-
-        @Override
+        
+         @Override
         public void propertyChange(PropertyChangeEvent event) {
-            if (preferenceKeys.contains(event.getProperty())) {
+            if (colorPreferenceKeys.contains(event.getProperty())) {
                 if (getSourceViewer() instanceof SourceViewer) {
                     ((SourceViewer) getSourceViewer()).unconfigure();
                     initializeEditor();
                     getSourceViewer().configure(sourceViewerConfiguration);
                 }
+            }
+            if (ALL_VALIDATION_PREFS.contains(event.getProperty())) {
+                Activator.getDefault().getSchema().allowJsonRefInContext(event.getProperty(),
+                        (Boolean) event.getNewValue());
+                validate();
             }
         }
     };

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -181,7 +181,7 @@ public class SwaggerEditor extends YEdit implements IShowInSource, IShowInTarget
             colorPreferenceKeys.add(PreferenceConstants.UNDERLINE_CONSTANT);
         }
         
-         @Override
+        @Override
         public void propertyChange(PropertyChangeEvent event) {
             if (colorPreferenceKeys.contains(event.getProperty())) {
                 if (getSourceViewer() instanceof SourceViewer) {
@@ -191,7 +191,8 @@ public class SwaggerEditor extends YEdit implements IShowInSource, IShowInTarget
                 }
             }
             if (ALL_VALIDATION_PREFS.contains(event.getProperty())) {
-                // Boolean comes from changing a value, String comes when restoring the default value as it uses getDefaultString(name)
+                // Boolean comes from changing a value, String comes when restoring the default value as it uses
+                // getDefaultString(name)
                 boolean newValue = event.getNewValue() instanceof Boolean ? (Boolean) event.getNewValue()
                         : Boolean.valueOf((String) event.getNewValue());
                 Activator.getDefault().getSchema().allowJsonRefInContext(event.getProperty(), newValue);

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -191,8 +191,10 @@ public class SwaggerEditor extends YEdit implements IShowInSource, IShowInTarget
                 }
             }
             if (ALL_VALIDATION_PREFS.contains(event.getProperty())) {
-                Activator.getDefault().getSchema().allowJsonRefInContext(event.getProperty(),
-                        (Boolean) event.getNewValue());
+                // Boolean comes from changing a value, String comes when restoring the default value as it uses getDefaultString(name)
+                boolean newValue = event.getNewValue() instanceof Boolean ? (Boolean) event.getNewValue()
+                        : Boolean.valueOf((String) event.getNewValue());
+                Activator.getDefault().getSchema().allowJsonRefInContext(event.getProperty(), newValue);
                 validate();
             }
         }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerPreferenceConstants.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerPreferenceConstants.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.preferences;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+
+public class SwaggerPreferenceConstants {
+
+    public static String VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT = "validation.ref.security_definitions"; //$NON-NLS-1$
+    public static String VALIDATION_REF_SECURITY_SCHEME_OBJECT = "validation.ref.security_scheme_object"; //$NON-NLS-1$
+    public static String VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY = "validation.ref.security_requirements_array"; //$NON-NLS-1$
+    public static String VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT = "validation.ref.security_requirement_object"; //$NON-NLS-1$
+
+    public static final List<String> ALL_VALIDATION_PREFS = Lists.newArrayList(//
+            VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, //
+            VALIDATION_REF_SECURITY_SCHEME_OBJECT, //
+            VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, //
+            VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT);
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerPreferenceInitializer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerPreferenceInitializer.java
@@ -84,8 +84,8 @@ public class SwaggerPreferenceInitializer extends AbstractPreferenceInitializer 
         store.setDefault(PreferenceConstants.ITALIC_CONSTANT, false);
         store.setDefault(PreferenceConstants.UNDERLINE_CONSTANT, false);
         
-        store.setDefault(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, true);
-        store.setDefault(VALIDATION_REF_SECURITY_SCHEME_OBJECT, true);
+        store.setDefault(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, false);
+        store.setDefault(VALIDATION_REF_SECURITY_SCHEME_OBJECT, false);
         store.setDefault(VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, false);
         store.setDefault(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, false);
     }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerPreferenceInitializer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerPreferenceInitializer.java
@@ -17,6 +17,7 @@ import org.eclipse.jface.preference.PreferenceConverter;
 import org.eclipse.swt.graphics.RGB;
 
 import com.reprezen.swagedit.Activator;
+import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.*;
 
 /*
  * SwagEdit default preference values.
@@ -82,6 +83,11 @@ public class SwaggerPreferenceInitializer extends AbstractPreferenceInitializer 
         store.setDefault(PreferenceConstants.BOLD_CONSTANT, true);
         store.setDefault(PreferenceConstants.ITALIC_CONSTANT, false);
         store.setDefault(PreferenceConstants.UNDERLINE_CONSTANT, false);
+        
+        store.setDefault(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, true);
+        store.setDefault(VALIDATION_REF_SECURITY_SCHEME_OBJECT, true);
+        store.setDefault(VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, false);
+        store.setDefault(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, false);
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
@@ -15,16 +15,23 @@ import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALID
 import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT;
 import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_SCHEME_OBJECT;
 
+import org.eclipse.jface.layout.GridDataFactory;
+import org.eclipse.jface.layout.GridLayoutFactory;
 import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
 import com.reprezen.swagedit.Activator;
 
-public class SwaggerValidationPreferences extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class SwaggerValidationPreferences extends FieldEditorPreferencePage
+        implements IWorkbenchPreferencePage, IPropertyChangeListener {
 
     public SwaggerValidationPreferences() {
+        super(FieldEditorPreferencePage.GRID);
         setPreferenceStore(Activator.getDefault().getPreferenceStore());
         setDescription("Swagger preferences for validation");
     }
@@ -35,10 +42,17 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage impl
 
     @Override
     protected void createFieldEditors() {
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, "Security Definitions Object", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_SCHEME_OBJECT, "Security Scheme Object", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, "Security Requirements Array", getFieldEditorParent()));
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, "Security Requirement Object", getFieldEditorParent()));
+        Group group = new Group(getFieldEditorParent(), SWT.SHADOW_OUT);
+        GridLayoutFactory.fillDefaults().applyTo(group);
+        GridDataFactory.fillDefaults().grab(true, false).indent(0, 10).applyTo(group);
+        group.setText("Allow JSON references in additional contexts:");
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, "Security Definitions Object",
+                group));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_SCHEME_OBJECT, "Security Scheme Object", group));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, "Security Requirements Array",
+                group));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, "Security Requirement Object",
+                group));
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.preferences;
+
+import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT;
+import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY;
+import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT;
+import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_SCHEME_OBJECT;
+
+import org.eclipse.jface.preference.BooleanFieldEditor;
+import org.eclipse.jface.preference.FieldEditorPreferencePage;
+import org.eclipse.ui.IWorkbench;
+import org.eclipse.ui.IWorkbenchPreferencePage;
+
+import com.reprezen.swagedit.Activator;
+
+public class SwaggerValidationPreferences extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+
+    public SwaggerValidationPreferences() {
+        setPreferenceStore(Activator.getDefault().getPreferenceStore());
+        setDescription("Swagger preferences for validation");
+    }
+
+    @Override
+    public void init(IWorkbench workbench) {
+    }
+
+    @Override
+    protected void createFieldEditors() {
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, "Security Definitions Object", getFieldEditorParent()));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_SCHEME_OBJECT, "Security Scheme Object", getFieldEditorParent()));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, "Security Requirements Array", getFieldEditorParent()));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, "Security Requirement Object", getFieldEditorParent()));
+    }
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
@@ -21,7 +21,9 @@ import org.eclipse.jface.preference.BooleanFieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
+import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
@@ -31,6 +33,7 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage
         implements IWorkbenchPreferencePage, IPropertyChangeListener {
 
     public SwaggerValidationPreferences() {
+        // GRID is needed because we are not attaching the editor fields directly to FieldEditorParent, but to its child
         super(FieldEditorPreferencePage.GRID);
         setPreferenceStore(Activator.getDefault().getPreferenceStore());
         setDescription("Swagger preferences for validation");
@@ -42,17 +45,23 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage
 
     @Override
     protected void createFieldEditors() {
-        Group group = new Group(getFieldEditorParent(), SWT.SHADOW_OUT);
-        GridLayoutFactory.fillDefaults().applyTo(group);
-        GridDataFactory.fillDefaults().grab(true, false).indent(0, 10).applyTo(group);
-        group.setText("Allow JSON references in additional contexts:");
+        // IMPORTANT: FieldEditorPreferencePage does not work very well with complex layouts and nested widgets.
+        // Consider switching to com.modelsolv.reprezen.generators.ui.preferences.GroupedFieldEditorPreferencePage from
+        // the RepreZen repo before modifying it
+        Composite refValidationComposite = new Composite(getFieldEditorParent(), SWT.BORDER);
+        GridLayoutFactory.fillDefaults().applyTo(refValidationComposite);
+        GridDataFactory.fillDefaults().grab(true, false).indent(0, 10).applyTo(refValidationComposite);
+
+        Label header = new Label(refValidationComposite, SWT.NONE);
+        header.setText("Allow JSON references in additional contexts:");
+
         addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, "Security Definitions Object",
-                group));
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_SCHEME_OBJECT, "Security Scheme Object", group));
+                refValidationComposite));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_SCHEME_OBJECT, "Security Scheme Object", refValidationComposite));
         addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, "Security Requirements Array",
-                group));
+                refValidationComposite));
         addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, "Security Requirement Object",
-                group));
+                refValidationComposite));
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
@@ -22,7 +22,6 @@ import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Group;
 import org.eclipse.swt.widgets.Label;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/SwaggerSchema.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/SwaggerSchema.java
@@ -10,6 +10,8 @@
  *******************************************************************************/
 package com.reprezen.swagedit.schema;
 
+import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
@@ -18,6 +20,7 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.reprezen.swagedit.json.references.JsonReference;
@@ -35,7 +38,7 @@ public class SwaggerSchema {
 
     private JsonSchema swaggerType;
     private JsonSchema coreType;
-    private Map<String, ArrayNode> jsonRefContexts = Maps.newHashMap();
+    private Map<String, JsonNode> jsonRefContexts = Maps.newHashMap();
     
     private final JsonNode refToJsonReferenceNode = mapper.createObjectNode().put("$ref", "#/definitions/jsonReference");
 
@@ -151,28 +154,34 @@ public class SwaggerSchema {
         swaggerType.setType(new ObjectTypeDefinition(swaggerType, JsonPointer.compile(""), content));
         try {
             JsonNode definitionsNode = asJson().get("definitions");
+            // FIXME
             jsonRefContexts.put(SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT,
-                    (ArrayNode) definitionsNode.get("securityDefinitions").get("additionalProperties").get("oneOf"));
+                    definitionsNode.get("securityDefinitions"));
 
             jsonRefContexts.put(SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_SCHEME_OBJECT,
-                    (ArrayNode) definitionsNode.get("security").get("oneOf").get(0).get("items").get("oneOf"));
-            
+                    (ArrayNode) definitionsNode.get("securityDefinitions").get("additionalProperties").get("oneOf"));
+                    
             jsonRefContexts.put(SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY,
                     (ArrayNode) definitionsNode.get("security").get("oneOf"));
 
             jsonRefContexts.put(SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT,
-                    (ArrayNode) definitionsNode.get("securityRequirement").get("additionalProperties").get("items").get("oneOf"));
- 
+                    (ArrayNode) definitionsNode.get("security").get("oneOf").get(0).get("items").get("oneOf"));
+
         } catch (Exception e) {
             e.printStackTrace();
         }
     }
 
     public void allowJsonRefInContext(String jsonReferenceContext, boolean allow) {
-        ArrayNode definition = jsonRefContexts.get(jsonReferenceContext);
-        if (definition == null) {
+        if (jsonRefContexts.get(jsonReferenceContext) == null) {
             throw new IllegalArgumentException("Invalid JSON Reference Context: " + jsonReferenceContext);
         }
+        // special case
+        if (VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT.equals(jsonReferenceContext)) {
+            allowJsonRefInSecurityDefinitionsObject(allow);
+            return;
+        }
+        ArrayNode definition = (ArrayNode) jsonRefContexts.get(jsonReferenceContext);
         int lastIndex = definition.size() - 1;
         JsonNode lastElement = definition.get(lastIndex);
         boolean alreadyHasJsonReference = refToJsonReferenceNode.equals(lastElement);
@@ -184,6 +193,16 @@ public class SwaggerSchema {
             if (alreadyHasJsonReference) {
                 definition.remove(lastIndex);
             }
+        }
+    }
+
+    protected void allowJsonRefInSecurityDefinitionsObject(boolean allow) {
+        ObjectNode definition = (ObjectNode) jsonRefContexts.get(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT);
+        if (allow) {
+            ObjectNode propertiesNode = definition.putObject("properties");
+            propertiesNode.putObject("$ref").put("type", "string");
+        } else {
+            definition.remove("properties");
         }
     }
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/SwaggerSchema.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/SwaggerSchema.java
@@ -154,7 +154,7 @@ public class SwaggerSchema {
         swaggerType.setType(new ObjectTypeDefinition(swaggerType, JsonPointer.compile(""), content));
         try {
             JsonNode definitionsNode = asJson().get("definitions");
-            // FIXME
+      
             jsonRefContexts.put(SwaggerPreferenceConstants.VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT,
                     definitionsNode.get("securityDefinitions"));
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/SwaggerSchema.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/SwaggerSchema.java
@@ -14,6 +14,7 @@ import static com.reprezen.swagedit.preferences.SwaggerPreferenceConstants.VALID
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.core.JsonPointer;
@@ -22,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Strings;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.reprezen.swagedit.json.references.JsonReference;
 import com.reprezen.swagedit.model.AbstractNode;
@@ -182,16 +184,17 @@ public class SwaggerSchema {
             return;
         }
         ArrayNode definition = (ArrayNode) jsonRefContexts.get(jsonReferenceContext);
-        int lastIndex = definition.size() - 1;
-        JsonNode lastElement = definition.get(lastIndex);
-        boolean alreadyHasJsonReference = refToJsonReferenceNode.equals(lastElement);
+        // should preserve order of the original ArrayNode._children
+        List<JsonNode> children = Lists.newArrayList(definition.elements());
+        int indexOfJsonReference = children.indexOf(refToJsonReferenceNode);
+        boolean alreadyHasJsonReference = indexOfJsonReference > -1;
         if (allow) {
             if (!alreadyHasJsonReference) {
                 definition.add(refToJsonReferenceNode.deepCopy());
             }
         } else { // disallow
             if (alreadyHasJsonReference) {
-                definition.remove(lastIndex);
+                definition.remove(indexOfJsonReference);
             }
         }
     }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/schema.json
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/schema.json
@@ -1175,11 +1175,7 @@
       "additionalProperties": {
         "type": "array",
         "items": {
-	      "oneOf": [
-	        {
-              "type": "string"
-	        }
-	      ]
+	       "type": "string"
         },
         "uniqueItems": true
       }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/schema.json
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/schema.json
@@ -1166,7 +1166,8 @@
 	          "$ref": "#/definitions/securityRequirement"
 	       }]
 	     }  
-	   }],
+	   }
+	   ],
       "uniqueItems": true
     },
     "securityRequirement": {
@@ -1257,18 +1258,6 @@
             "$ref": "#/definitions/oauth2AccessCodeSecurity"
           }
         ]
-      }
-    },
-    "elementRef": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": [
-        "$ref"
-      ],
-      "properties": {
-        "$ref": {
-        "type": "string"
-        }
       }
     },
     "basicAuthenticationSecurity": {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/schema.json
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/schema.json
@@ -1158,10 +1158,15 @@
       }
     },
     "security": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/securityRequirement"
-      },
+      "oneOf": [
+	    {
+	    "type": "array",
+	     "items": {
+	     "oneOf": [ {
+	          "$ref": "#/definitions/securityRequirement"
+	       }]
+	     }  
+	   }],
       "uniqueItems": true
     },
     "securityRequirement": {
@@ -1169,7 +1174,11 @@
       "additionalProperties": {
         "type": "array",
         "items": {
-          "type": "string"
+	      "oneOf": [
+	        {
+              "type": "string"
+	        }
+	      ]
         },
         "uniqueItems": true
       }
@@ -1248,6 +1257,18 @@
             "$ref": "#/definitions/oauth2AccessCodeSecurity"
           }
         ]
+      }
+    },
+    "elementRef": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "$ref"
+      ],
+      "properties": {
+        "$ref": {
+        "type": "string"
+        }
       }
     },
     "basicAuthenticationSecurity": {


### PR DESCRIPTION
#257 User-configurable severity for unsupported $ref context 
See proposed GUI description inZEN-3180. 
New preferences page:
<img width="660" alt="screen shot 2017-01-18 at 12 44 34 pm" src="https://cloud.githubusercontent.com/assets/644582/22081733/bfa7aa7c-dd92-11e6-8cb2-0271f2adc7ce.png">

Screencast:
![validation_ref](https://cloud.githubusercontent.com/assets/644582/22084826/8dd11742-dd9f-11e6-9b78-cae48df48fd8.gif)


Swagger spec used in the screencast demo:
```yaml
swagger: '2.0'
info:
  version: '2.0.0'
  title:  Some API
  description: Provides an interface for something
basePath: /usage/2
consumes:
  - application/json
produces:
  - application/json
    
paths: 
  /resource:
    get:
 # Security Requirement Object
      security: 
        - $ref: './security.yaml#/security/0' 
      responses:
        '200':
          description: OK

# Security Requirement Object
security: 
  - api_key_query_token: []
  - api_key_header: []
  - $ref: './security.yaml#/security/0' 

# Security Requirements Array
#security: 
#  $ref: './security.yaml#/security'  
 

#  Security Scheme Object
#securityDefinitions: 
#  api_key_query_token:
#    $ref: './security.yaml#/securityDefinitions/api_key'   

# Security Definitions Object
securityDefinitions: 
  $ref: './security.yaml#/securityDefinitions'   
```

Referenced security.yaml:
```yaml
swagger: '2.0'
info:
  version: '2'
  title: Common Security Objects
paths: {}

securityDefinitions:

  api_key:
    type: apiKey
    name: api_key
    in: header

  petstore_auth:
    type: oauth2
    authorizationUrl: http://swagger.io/api/oauth/dialog
    flow: implicit
    scopes:
      write:pets: modify pets in your account
      read:pets: read your pets
  
security:
  - api_key: []
  - petstore_auth: []

```
