### PR TITLE
#262 Use of type: null masks subsequent errors

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/NullValueValidationTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/NullValueValidationTest.xtend
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.validation
+
+import com.reprezen.swagedit.editor.SwaggerDocument
+import org.junit.Test
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+
+class NullValueValidationTest {
+
+	val validator = new Validator
+	val document = new SwaggerDocument
+
+	@Test
+	def void testErrorOnNullValueForType() {
+		val content = '''
+			swagger: "2.0"
+			info:
+			  version: 1.0.0
+			  title: some definitions
+			
+			paths: {}
+			
+			definitions:
+			
+			  Phones:
+			    type: object
+			    properties:
+			      phoneId:
+			        type: null
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null)
+		assertEquals(1, errors.size())
+		assertTrue(errors.findFirst[true].getMessage().contains("value null is not allowed"))
+		assertThat(errors.findFirst[true].line, equalTo(14))
+	}
+
+	@Test
+	def void testOkOnNullStringForType() {
+		val content = '''
+			swagger: "2.0"
+			info:
+			  version: 1.0.0
+			  title: some definitions
+			
+			paths: {}
+			
+			definitions:
+			
+			  Phones:
+			    type: object
+			    properties:
+			      phoneId:
+			        type: "null"
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null)
+		assertEquals(0, errors.size())
+	}
+
+	@Test
+	def void testOkOnNullValueInVendorExtension() {
+		val content = '''
+			swagger: "2.0"
+			info:
+			  version: 1.0.0
+			  title: some definitions
+			
+			paths: {}
+			
+			definitions:
+			
+			  Phones:
+			    type: object
+			    properties:
+			      phoneId:
+			        type: string
+			        x-null-prop: null
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null)
+		assertEquals(0, errors.size())
+	}
+
+	@Test
+	def void testOkOnNullValueInExample() {
+		val content = '''
+			swagger: "2.0"
+			info:
+			  title: Simple API overview
+			  version: v2
+			  
+			paths:
+			  /myurl:
+			    get:
+			      responses:
+			        200:
+			          description: desc
+			          examples:
+			            application/json: |-
+			              {
+			                  "nullProperty": null
+			              }
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null)
+		assertEquals(0, errors.size())
+	}
+
+	@Test
+	def void testErrorOnNullValueForDescription() {
+		val content = '''
+			swagger: "2.0"
+			info:
+			  version: 1.0.0
+			  title: some definitions
+			
+			paths: {}
+			
+			definitions:
+			
+			  Phones:
+			    type: object
+			    properties:
+			      phoneId:
+			        type: string
+			        description: null
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null)
+		assertEquals(1, errors.size())
+		assertTrue(errors.findFirst[true].getMessage().contains("value of type null is not allowed"))
+		assertThat(errors.findFirst[true].line, equalTo(15))
+	}
+
+}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/NullValueValidationTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/NullValueValidationTest.xtend
@@ -45,7 +45,7 @@ class NullValueValidationTest {
 
 		val errors = validator.validate(document, null)
 		assertEquals(1, errors.size())
-		assertTrue(errors.findFirst[true].getMessage().contains("value null is not allowed"))
+		assertThat(errors.findFirst[true].getMessage(), containsString('The null value is not allowed for type, did you mean the "null" string (quoted)?'))
 		assertThat(errors.findFirst[true].line, equalTo(14))
 	}
 
@@ -155,7 +155,7 @@ class NullValueValidationTest {
 
 		val errors = validator.validate(document, null)
 		assertEquals(1, errors.size())
-		assertTrue(errors.findFirst[true].getMessage().contains("value of type null is not allowed"))
+		assertThat(errors.findFirst[true].getMessage(), containsString("value of type null is not allowed"))
 		assertThat(errors.findFirst[true].line, equalTo(15))
 	}
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
@@ -27,6 +27,7 @@ public class Messages extends NLS {
     public static String outline_proposal_workspace;
 
     // errors
+    public static String error_nullType;
     public static String error_typeNoMatch;
     public static String error_notInEnum;
     public static String error_additional_properties_not_allowed;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
@@ -15,6 +15,7 @@ swagedit_wizard_title = Swagger Spec
 swagedit_wizard_description = This wizard creates a new Swagger Spec in YAML format, which can be opened in SwagEdit.
 
 # errors
+error_nullType = The null value is not allowed for type, did you mean the "null" string (quoted)?
 error_typeNoMatch = value of type %s is not allowed, value should be of type %s
 error_notInEnum = value %s is not allowed, value should be one of %s
 error_additional_properties_not_allowed = object has properties %s which are not allowed

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ErrorProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ErrorProcessor.java
@@ -169,6 +169,12 @@ public class ErrorProcessor {
             expect = expected.asText();
         }
 
+        if ("null".equals(found.asText())) {
+            String pointer = ValidationUtil.getInstancePointer(error);
+            if (pointer != null && ValidationUtil.isInDefinition(pointer) && pointer.endsWith("/type")) {
+                return Messages.error_nullType;
+            }
+        }
         return String.format(Messages.error_typeNoMatch, found.asText(), expect);
     }
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ValidationUtil.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/ValidationUtil.java
@@ -21,6 +21,16 @@ import org.yaml.snakeyaml.nodes.ScalarNode;
 import com.fasterxml.jackson.databind.JsonNode;
 
 public class ValidationUtil {
+    
+    public static boolean isInDefinition(String pointerString) {
+        return pointerString.startsWith("/definitions") || pointerString.endsWith("/schema");
+    }
+    
+    public static String getInstancePointer(JsonNode error) {
+        if (!error.has("instance") || !error.get("instance").has("pointer"))
+            return null;
+        return error.get("instance").get("pointer").asText();
+    }
 
     /*
      * Returns the line for which an error message has been produced.
@@ -34,10 +44,7 @@ public class ValidationUtil {
      * The Node matching the path is found by the methods findNode().
      */
     public static int getLine(JsonNode error, Node yamlTree) {
-        if (!error.has("instance") || !error.get("instance").has("pointer"))
-            return 1;
-
-        String path = error.get("instance").get("pointer").asText();
+        String path = getInstancePointer(error);
 
         if (path == null || path.isEmpty())
             return 1;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
@@ -193,14 +193,9 @@ public class Validator {
     protected void checkObjectTypeDefinition(Set<SwaggerError> errors, AbstractNode node) {
         if (node instanceof ObjectNode) {
             JsonPointer ptr = node.getPointer();
-            if (ptr != null) {
-                if (ptr.toString().startsWith("/definitions")) {
-                    checkMissingType(errors, node);
-                    checkMissingRequiredProperties(errors, node);
-                } else if (ptr.toString().endsWith("/schema")) {
-                    checkMissingType(errors, node);
-                    checkMissingRequiredProperties(errors, node);
-                }
+            if (ptr != null && ValidationUtil.isInDefinition(ptr.toString())) {
+                checkMissingType(errors, node);
+                checkMissingRequiredProperties(errors, node);
             }
         }
     }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
@@ -179,7 +179,7 @@ public class Validator {
     protected boolean hasArrayType(AbstractNode node) {
         if (node.isObject() && node.get("type") instanceof ValueNode) {
             ValueNode typeValue = node.get("type").asValue();
-            return "array".equalsIgnoreCase(typeValue.getValue().toString());
+            return typeValue.getValue() != null && "array".equalsIgnoreCase(typeValue.getValue().toString());
         }
         return false;
     }


### PR DESCRIPTION
## Tests
`NullValueValidationTest` checks for invalid `null` values as well as cases when `null`s are actually valid values in vendor extensions and examples.

## Screenshots
Null definition type has a special message suggesting to use the `"null"` string:
<img width="893" alt="screen shot 2017-02-13 at 1 04 55 pm" src="https://cloud.githubusercontent.com/assets/644582/22896240/525ee470-f1ed-11e6-8a2a-0e89c2bf5007.png">

Other null value have a standard message:
<img width="909" alt="screen shot 2017-02-13 at 1 03 35 pm" src="https://cloud.githubusercontent.com/assets/644582/22896241/54729f04-f1ed-11e6-818a-3ccae670ab2e.png">