### PR TITLE
ZEN-3404 SwagEdit: Code assist doesn't work in responses/default/$ref

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/JsonReferenceProposalProviderTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/JsonReferenceProposalProviderTest.xtend
@@ -136,6 +136,7 @@ class JsonReferenceProposalProviderTest {
 
 		// responses
 		assertTrue("/paths/~1foo/get/responses/200/$ref".matches(JsonReferenceProposalProvider.RESPONSE_REGEX))
+		assertTrue("/paths/~1foo/get/responses/default/$ref".matches(JsonReferenceProposalProvider.RESPONSE_REGEX))
 
 		// parameters
 		assertTrue("/paths/~1/get/parameters/0/$ref".matches(JsonReferenceProposalProvider.PARAMETER_REGEX))

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/JsonReferenceProposalProvider.java
@@ -33,7 +33,7 @@ import com.reprezen.swagedit.utils.URLUtils;
 public class JsonReferenceProposalProvider {
 
     protected static final String SCHEMA_DEFINITION_REGEX = "^/definitions/(\\w+/)+\\$ref|.*schema/(\\w+/)?\\$ref";
-    protected static final String RESPONSE_REGEX = ".*responses/\\d+/\\$ref";
+    protected static final String RESPONSE_REGEX = ".*responses/(\\d+|default)/\\$ref";
     protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
     protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref";
 


### PR DESCRIPTION
```
---
swagger: "2.0"
info:
  version: 1.0.0
  title: Address path item 
  description: This is a component file, used within the Uber API specification.

responses:

  ErrorResponse:
    description: Ouf
    schema:
      $ref: "./uber_schemas.yaml#/definitions/Error"
      
paths:
  /products:
    # Operations are identified by an HTTP method.  
    get:
      summary: Product Types
      description: desc
      tags: 
        - Products
      responses:  
        200:
           $ref: "#/responses/ErrorResponse"
        default:
          # Did not work before the fix, works now
          $ref: "#/responses/ErrorResponse"
```