### PR TITLE
ZEN-3395 Swagger schema property with missing type not handled correctly

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
@@ -551,7 +551,7 @@ class ValidatorTest {
 
 		val errors = validator.validate(document, null)		
 		assertEquals(1, errors.size())
-		assertEquals(Messages.error_type_missing, errors.get(0).message)
+		assertEquals(Messages.error_object_type_missing, errors.get(0).message)
 	}
 
 	@Test
@@ -639,7 +639,7 @@ class ValidatorTest {
 
 		val errors = validator.validate(document, null)		
 		assertEquals(1, errors.size())
-		assertEquals(Messages.error_type_missing, errors.get(0).message)
+		assertEquals(Messages.error_object_type_missing, errors.get(0).message)
 	}
 
 	@Test

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -226,4 +226,10 @@
         </fontDefinition>
    </extension>
    
+   <extension point="org.eclipse.ui.ide.markerResolution">
+      <markerResolutionGenerator
+         markerType="org.eclipse.core.resources.problemmarker"
+         class="com.reprezen.swagedit.validation.QuickFixer"/>
+   </extension>
+   
 </plugin>

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/Messages.java
@@ -39,6 +39,7 @@ public class Messages extends NLS {
     public static String error_array_items_should_be_object;
 
     public static String error_array_missing_items;
+    public static String error_object_type_missing;
     public static String error_type_missing;
     public static String error_wrong_type;
     public static String error_missing_properties;

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/messages.properties
@@ -28,7 +28,8 @@ error_invalid_reference= Invalid Reference Syntax - The referenced path or URI m
 The value must be a valid JSON Reference (for external references) or JSON Pointer (for local references), and must resolve to an object of the expected type.
 error_array_missing_items=Invalid array definition, items type should be present
 error_array_items_should_be_object=Invalid array definition, items should be an object 
-error_type_missing = Invalid definition, type is missing
+error_object_type_missing=Invalid definition, object type is missing
+error_type_missing=Invalid definition, type is missing
 error_wrong_type = Invalid type, should be object
 error_missing_properties = Invalid type definition, object has a required field but is missing a properties field
 warning_simple_reference = Simplified reference syntax is deprecated. The reference should be a valid JSON pointer.

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/TypeDefinition.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/schema/TypeDefinition.java
@@ -55,6 +55,10 @@ public class TypeDefinition {
     public TypeDefinition getPropertyType(String property) {
         return null;
     }
+    
+    public JsonNode getContent() {
+        return content;
+    }
 
     /**
      * 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
@@ -10,6 +10,9 @@
  *******************************************************************************/
 package com.reprezen.swagedit.validation;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
@@ -56,6 +59,7 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
     }
 
     public static class FixMissingObjectType extends TextDocumentMarkerResolution {
+        private static final Pattern WHITESPACE_PATTERN = Pattern.compile("(\\s+)\\S.*", Pattern.DOTALL);
 
         public String getLabel() {
             return "Set object type to schema definition";
@@ -79,8 +83,9 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
 
         protected String getIndent(IDocument document, int line) throws BadLocationException {
             String definitionLine = document.get(document.getLineOffset(line - 1), document.getLineLength(line - 1));
-            // TODO use definitionLine to calculate indent
-            return "    ";
+            Matcher m = WHITESPACE_PATTERN.matcher(definitionLine);
+            final String definitionIndent = m.matches() ? m.group(1) : "";
+            return definitionIndent + "  ";
         }
     }
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.validation;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.resources.IResource;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.TextUtilities;
+import org.eclipse.ui.IEditorPart;
+import org.eclipse.ui.IMarkerResolution;
+import org.eclipse.ui.IMarkerResolutionGenerator2;
+import org.eclipse.ui.IWorkbenchPage;
+import org.eclipse.ui.PartInitException;
+import org.eclipse.ui.PlatformUI;
+import org.eclipse.ui.ide.IDE;
+import org.eclipse.ui.part.FileEditorInput;
+import org.eclipse.ui.texteditor.ITextEditor;
+
+import com.reprezen.swagedit.Messages;
+
+public class QuickFixer implements IMarkerResolutionGenerator2 {
+
+    @Override
+    public IMarkerResolution[] getResolutions(IMarker marker) {
+        if (isMissingObjectType(marker)) {
+            return new IMarkerResolution[] { new FixMissingObjectType() };
+        }
+        return new IMarkerResolution[0];
+    }
+
+    @Override
+    public boolean hasResolutions(IMarker marker) {
+        return isMissingObjectType(marker);
+    }
+
+    private boolean isMissingObjectType(IMarker marker) {
+        try {
+            return Messages.error_object_type_missing.equals(marker.getAttribute(IMarker.MESSAGE));
+        } catch (CoreException e) {
+            return false;
+        }
+    }
+
+    public static class FixMissingObjectType implements IMarkerResolution {
+
+        public String getLabel() {
+            return "Set object type to schema definition";
+        }
+
+        public void run(IMarker marker) {
+            IDocument document = getDocument(marker);
+            if (document == null) {
+                return;
+            }
+            int line;
+            try {
+                line = (int) marker.getAttribute(IMarker.LINE_NUMBER);
+            } catch (CoreException e) {
+                // TODO log
+                return;
+            }
+            // TODO add a new line if it's at the end of the document
+            int nextLineOffset;
+            try {
+                nextLineOffset = document.getLineOffset(line);
+                String definitionLine = document.get(document.getLineOffset(line - 1),
+                        document.getLineLength(line - 1));
+                // TODO use definitionLine to calculate indent
+                String indent = "    ";
+                document.replace(nextLineOffset, 0,
+                        indent + "type: object" + TextUtilities.getDefaultLineDelimiter(document));
+            } catch (BadLocationException e1) {
+                // TODO log
+                return;
+            }
+        }
+
+        protected IDocument getDocument(IMarker marker) {
+            IResource resource = marker.getResource();
+            if (resource.getType() != IResource.FILE) {
+                // TODO log
+                return null;
+            }
+            IFile file = (IFile) resource;
+            ITextEditor editor = openTextEditor(file);
+            if (editor == null) {
+                return null;
+            }
+            return editor.getDocumentProvider().getDocument(new FileEditorInput(file));
+        }
+
+        protected ITextEditor openTextEditor(IFile file) {
+            IWorkbenchPage page = PlatformUI.getWorkbench().getActiveWorkbenchWindow().getActivePage();
+            IEditorPart part;
+            try {
+                part = IDE.openEditor(page, file, true);
+            } catch (PartInitException e1) {
+                // log error
+                return null;
+            }
+            return part instanceof ITextEditor ? (ITextEditor) part : null;
+        }
+    }
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
@@ -13,12 +13,14 @@ package com.reprezen.swagedit.validation;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.dadacoalition.yedit.preferences.PreferenceConstants;
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.resources.IMarker;
 import org.eclipse.core.resources.IResource;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.IStatus;
 import org.eclipse.core.runtime.Status;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.TextUtilities;
@@ -32,6 +34,7 @@ import org.eclipse.ui.ide.IDE;
 import org.eclipse.ui.part.FileEditorInput;
 import org.eclipse.ui.texteditor.ITextEditor;
 
+import com.google.common.base.Strings;
 import com.reprezen.swagedit.Activator;
 import com.reprezen.swagedit.Messages;
 
@@ -85,7 +88,12 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
             String definitionLine = document.get(document.getLineOffset(line - 1), document.getLineLength(line - 1));
             Matcher m = WHITESPACE_PATTERN.matcher(definitionLine);
             final String definitionIndent = m.matches() ? m.group(1) : "";
-            return definitionIndent + "  ";
+            return definitionIndent + Strings.repeat(" ", getTabWidth());
+        }
+
+        private int getTabWidth() {
+            IPreferenceStore prefs = org.dadacoalition.yedit.Activator.getDefault().getPreferenceStore();
+            return prefs.getInt(PreferenceConstants.SPACES_PER_TAB);
         }
     }
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.reprezen.swagedit.Messages;
 import com.reprezen.swagedit.editor.SwaggerDocument;
+import com.reprezen.swagedit.json.references.JsonReference;
 import com.reprezen.swagedit.json.references.JsonReferenceFactory;
 import com.reprezen.swagedit.json.references.JsonReferenceValidator;
 import com.reprezen.swagedit.model.AbstractNode;
@@ -226,7 +227,9 @@ public class Validator {
 
     private boolean isSchemaDefinition(AbstractNode node) {
         // need to use getContent() because asJson() returns resolvedValue is some subclasses
-        return schemaRefTemplate.equals(node.getType().getContent());
+        return schemaRefTemplate.equals(node.getType().getContent()) //
+                && node.get(JsonReference.PROPERTY) == null //
+                && node.get("allOf") == null;
     }
 
     /**

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/Validator.java
@@ -209,7 +209,7 @@ public class Validator {
     protected void checkMissingType(Set<SwaggerError> errors, AbstractNode node) {
         if (node.get("properties") != null) {
             if (node.get("type") == null) {
-                errors.add(error(node, IMarker.SEVERITY_ERROR, Messages.error_type_missing));
+                errors.add(error(node, IMarker.SEVERITY_WARNING, Messages.error_type_missing));
             } else {
                 AbstractNode typeValue = node.get("type");
                 if (!(typeValue instanceof ValueNode) || !Objects.equals("object", typeValue.asValue().getValue())) {


### PR DESCRIPTION
* Use validation warning instead of error
* Add a quick fix for missing object type (the type is presumably object if the element has the `properties`). It's our first quick-fix in SwagEdit.
<img width="379" alt="screen shot 2017-04-04 at 11 11 32 am" src="https://cloud.githubusercontent.com/assets/644582/24664083/b7e2d872-1927-11e7-8a49-583749887b4b.png">
<img width="571" alt="screen shot 2017-04-10 at 2 04 33 pm" src="https://cloud.githubusercontent.com/assets/644582/24875621/b3545b22-1df6-11e7-863f-905e83f554fa.png">

<img width="617" alt="screen shot 2017-04-04 at 11 13 59 am" src="https://cloud.githubusercontent.com/assets/644582/24664147/e088ffd6-1927-11e7-8258-a58be7863db4.png">

* Add validation checks for non-object types:
<img width="402" alt="screen shot 2017-04-04 at 11 11 19 am" src="https://cloud.githubusercontent.com/assets/644582/24664080/b3786ed2-1927-11e7-9653-d384e17c4b74.png">
<img width="349" alt="screen shot 2017-04-04 at 11 14 58 am" src="https://cloud.githubusercontent.com/assets/644582/24664175/f8234872-1927-11e7-8f13-8cb2043208b1.png">
