### PR TITLE
ZEN-3423 Performance optimizations

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerDocument.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerDocument.java
@@ -12,6 +12,8 @@ package com.reprezen.swagedit.editor;
 
 import java.io.IOException;
 import java.io.StringReader;
+import java.util.Timer;
+import java.util.TimerTask;
 
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
@@ -46,6 +48,8 @@ public class SwaggerDocument extends Document {
     private Exception jsonError;
     private Model model;
     private SwaggerSchema schema;
+    
+    private Timer modelParserTimer = null;
 
     public SwaggerDocument() {
         this.schema = Activator.getDefault() != null ? Activator.getDefault().getSchema() : new SwaggerSchema();
@@ -160,12 +164,21 @@ public class SwaggerDocument extends Document {
     }
 
     private void parseModel() {
-        try {
-            model = Model.parseYaml(schema, get());
-        } catch (Exception e) {
-            // e.printStackTrace();
-            model = null;
+        if (modelParserTimer != null) {
+            modelParserTimer.cancel();
         }
+        modelParserTimer = new Timer();
+        modelParserTimer.schedule(new TimerTask() {
+            @Override
+            public void run() {
+                try {
+                    model = Model.parseYaml(schema, get());
+                } catch (Exception e) {
+                    // e.printStackTrace();
+                    model = null;
+                }
+            }
+        }, 0);
     }
 
     /**

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -207,7 +207,9 @@ public class SwaggerEditor extends YEdit implements IShowInSource, IShowInTarget
     };
 
     private SwaggerContentOutlinePage contentOutline;
-    private static final String VALIDATE_JOB = "SwagEdit_validate";
+    
+    // Intentionally made non-static, so different editor parts will have different objects 
+    private final Object validateEditorContentsJobFamily = new Object();
 
     public SwaggerEditor() {
         super();
@@ -497,7 +499,9 @@ public class SwaggerEditor extends YEdit implements IShowInSource, IShowInTarget
     }
 
     protected void runValidate(final boolean onOpen) {
-        Job.getJobManager().cancel(VALIDATE_JOB);
+        // OK if several editor parts are open at the same time.
+        // Only validation jobs attached to the current part will be cancelled.
+        Job.getJobManager().cancel(validateEditorContentsJobFamily);
         new SafeWorkspaceJob("Update SwagEdit validation markers") {
 
             @Override
@@ -506,7 +510,7 @@ public class SwaggerEditor extends YEdit implements IShowInSource, IShowInTarget
             }
 
             public boolean belongsTo(Object family) {
-                return VALIDATE_JOB.equals(family);
+                return validateEditorContentsJobFamily.equals(family);
             };
         }.schedule();
     }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -615,7 +615,7 @@ public class SwaggerEditor extends YEdit implements IShowInSource, IShowInTarget
 
         public SafeWorkspaceJob(String name) {
             super(name);
-            setPriority(Job.INTERACTIVE);
+            setPriority(Job.LONG);
             IEditorInput editorInput = SwaggerEditor.this.getEditorInput();
             if (editorInput != null && editorInput instanceof FileEditorInput) {
                 setRule(((FileEditorInput) editorInput).getFile());


### PR DESCRIPTION
## Improvements
1. Discard previous validations on the same model if a new validation is scheduled. I also made the validation job “cancellable” - it means that now cancelling it in the GUI will actually make effect.
2. Model parsing was another memory-consuming operation because Jackson deserialization uses mutant-factories to provide thread-safeness. 
3. Change priority of the `SafeWorkspaceJob` to LONG. We use it for validation and model save, and these are long operations.

## First validation is always slow
Because we need to load JSON Schemas for Swagger and JSON Schema Core, it takes some time. As it’s a one-time thing, it’s out of scope of this PR.

## How to test
You need a big model, a good big model is attached to https://modelsolv.atlassian.net/browse/ZEN-2583 . It also has many validation warnings, it's good test performance of validation.
You may also need to decrease VM memory, as low as `-Xms200m -Xmx200m -XX:PermSize=100m -XX:MaxPermSize=100m` is sufficient. 