### PR TITLE
ZEN-3421 - enable Cmd+1 for Quick Fixes

### DIFF
--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerQuickAssistProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerQuickAssistProcessor.java
@@ -14,6 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import org.eclipse.core.resources.IMarker;
+import org.eclipse.core.runtime.CoreException;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.Position;
@@ -31,6 +32,8 @@ import org.eclipse.ui.IMarkerResolutionGenerator2;
 import org.eclipse.ui.texteditor.MarkerAnnotation;
 
 import com.google.common.collect.Lists;
+import com.reprezen.swagedit.Activator;
+import com.reprezen.swagedit.validation.QuickFixer.TextDocumentMarkerResolution;
 
 public class SwaggerQuickAssistProcessor implements IQuickAssistProcessor {
     private final IMarkerResolutionGenerator2 quickFixer;
@@ -126,7 +129,15 @@ public class SwaggerQuickAssistProcessor implements IQuickAssistProcessor {
 
         @Override
         public void apply(IDocument document) {
-            markerResolution.run(marker);
+            if (markerResolution instanceof TextDocumentMarkerResolution) {
+                try {
+                    ((TextDocumentMarkerResolution) markerResolution).processFix(document, marker);
+                } catch (CoreException e) {
+                    Activator.getDefault().getLog().log(e.getStatus());
+                }
+            } else {
+                markerResolution.run(marker);
+            }
         }
 
         @Override

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerQuickAssistProcessor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerQuickAssistProcessor.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.assist;
+
+import java.util.Iterator;
+import java.util.List;
+
+import org.eclipse.core.resources.IMarker;
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.Position;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.eclipse.jface.text.contentassist.IContextInformation;
+import org.eclipse.jface.text.quickassist.IQuickAssistInvocationContext;
+import org.eclipse.jface.text.quickassist.IQuickAssistProcessor;
+import org.eclipse.jface.text.source.Annotation;
+import org.eclipse.jface.text.source.IAnnotationModel;
+import org.eclipse.jface.text.source.ISourceViewer;
+import org.eclipse.swt.graphics.Image;
+import org.eclipse.swt.graphics.Point;
+import org.eclipse.ui.IMarkerResolution;
+import org.eclipse.ui.IMarkerResolutionGenerator2;
+import org.eclipse.ui.texteditor.MarkerAnnotation;
+
+import com.google.common.collect.Lists;
+
+public class SwaggerQuickAssistProcessor implements IQuickAssistProcessor {
+    private final IMarkerResolutionGenerator2 quickFixer;
+    private String errorMessage;
+
+    public SwaggerQuickAssistProcessor(IMarkerResolutionGenerator2 quickFixer) {
+        this.quickFixer = quickFixer;
+    }
+
+    @Override
+    public boolean canAssist(IQuickAssistInvocationContext invocationContext) {
+        return false;
+    }
+
+    @Override
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    @Override
+    public boolean canFix(Annotation annotation) {
+        if (annotation.isMarkedDeleted()) {
+            return false;
+        }
+        if (annotation instanceof MarkerAnnotation) {
+            MarkerAnnotation markerAnnotation = (MarkerAnnotation) annotation;
+            if (!markerAnnotation.isQuickFixableStateSet()) {
+                markerAnnotation.setQuickFixable(quickFixer.hasResolutions(markerAnnotation.getMarker()));
+            }
+            return markerAnnotation.isQuickFixable();
+        }
+        return false;
+    }
+
+    @Override
+    public ICompletionProposal[] computeQuickAssistProposals(IQuickAssistInvocationContext invocationContext) {
+        List<IMarker> markers;
+        try {
+            markers = getMarkersFor(invocationContext.getSourceViewer(), invocationContext.getOffset());
+        } catch (BadLocationException e) {
+            errorMessage = e.getMessage();
+            return new ICompletionProposal[0];
+        }
+        List<ICompletionProposal> result = Lists.newArrayList();
+        for (IMarker marker : markers) {
+            for (IMarkerResolution markerResolution : quickFixer.getResolutions(marker)) {
+                result.add(new MarkerResolutionProposal(marker, markerResolution));
+            }
+        }
+        return result.toArray(new ICompletionProposal[0]);
+    }
+
+    protected List<IMarker> getMarkersFor(ISourceViewer sourceViewer, int offset) throws BadLocationException {
+        final IDocument document = sourceViewer.getDocument();
+
+        int line = document.getLineOfOffset(offset);
+        int lineOffset = document.getLineOffset(line);
+
+        String delim = document.getLineDelimiter(line);
+        int delimLength = delim != null ? delim.length() : 0;
+        int lineLength = document.getLineLength(line) - delimLength;
+
+        return getMarkersFor(sourceViewer, lineOffset, lineLength);
+    }
+
+    protected List<IMarker> getMarkersFor(ISourceViewer sourceViewer, int lineOffset, int lineLength) {
+        List<IMarker> result = Lists.newArrayList();
+        IAnnotationModel annotationModel = sourceViewer.getAnnotationModel();
+        Iterator annotationIter = annotationModel.getAnnotationIterator();
+        while (annotationIter.hasNext()) {
+            Object annotation = annotationIter.next();
+            if (annotation instanceof MarkerAnnotation) {
+                MarkerAnnotation markerAnnotation = (MarkerAnnotation) annotation;
+                IMarker marker = markerAnnotation.getMarker();
+                Position markerPosition = annotationModel.getPosition(markerAnnotation);
+                if (markerPosition != null && markerPosition.overlapsWith(lineOffset, lineLength)) {
+                    result.add(marker);
+                }
+            }
+        }
+        return result;
+    }
+
+    public static class MarkerResolutionProposal implements ICompletionProposal {
+
+        private final IMarker marker;
+        private final IMarkerResolution markerResolution;
+
+        public MarkerResolutionProposal(IMarker marker, IMarkerResolution markerResolution) {
+            this.marker = marker;
+            this.markerResolution = markerResolution;
+        }
+
+        @Override
+        public void apply(IDocument document) {
+            markerResolution.run(marker);
+        }
+
+        @Override
+        public Point getSelection(IDocument document) {
+            return null;
+        }
+
+        @Override
+        public String getAdditionalProposalInfo() {
+            return null;
+        }
+
+        @Override
+        public String getDisplayString() {
+            return markerResolution.getLabel();
+        }
+
+        @Override
+        public Image getImage() {
+            return null;
+        }
+
+        @Override
+        public IContextInformation getContextInformation() {
+            return null;
+        }
+
+    }
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerSourceViewerConfiguration.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerSourceViewerConfiguration.java
@@ -27,6 +27,8 @@ import org.eclipse.jface.text.information.IInformationProvider;
 import org.eclipse.jface.text.information.IInformationProviderExtension;
 import org.eclipse.jface.text.information.IInformationProviderExtension2;
 import org.eclipse.jface.text.information.InformationPresenter;
+import org.eclipse.jface.text.quickassist.IQuickAssistAssistant;
+import org.eclipse.jface.text.quickassist.QuickAssistAssistant;
 import org.eclipse.jface.text.reconciler.IReconciler;
 import org.eclipse.jface.text.reconciler.MonoReconciler;
 import org.eclipse.jface.text.source.ISourceViewer;
@@ -34,10 +36,12 @@ import org.eclipse.swt.widgets.Shell;
 
 import com.reprezen.swagedit.Activator;
 import com.reprezen.swagedit.assist.SwaggerContentAssistProcessor;
+import com.reprezen.swagedit.assist.SwaggerQuickAssistProcessor;
 import com.reprezen.swagedit.editor.hyperlinks.DefinitionHyperlinkDetector;
 import com.reprezen.swagedit.editor.hyperlinks.JsonReferenceHyperlinkDetector;
 import com.reprezen.swagedit.editor.hyperlinks.PathParamHyperlinkDetector;
 import com.reprezen.swagedit.editor.outline.QuickOutline;
+import com.reprezen.swagedit.validation.QuickFixer;
 
 public class SwaggerSourceViewerConfiguration extends YEditSourceViewerConfiguration {
 
@@ -127,6 +131,14 @@ public class SwaggerSourceViewerConfiguration extends YEditSourceViewerConfigura
             informationPresenter.setSizeConstraints(60, 20, true, true);
         }
         return informationPresenter;
+    }
+    
+    @Override
+    public IQuickAssistAssistant getQuickAssistAssistant(ISourceViewer sourceViewer) {
+        QuickAssistAssistant assistant = new QuickAssistAssistant();
+        assistant.setQuickAssistProcessor(new SwaggerQuickAssistProcessor(new QuickFixer()));
+        assistant.setInformationControlCreator(getInformationControlCreator(sourceViewer));
+        return assistant;
     }
 
     private IInformationControlCreator getOutlineInformationControlCreator() {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
@@ -80,8 +80,9 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
                         + document.getLineInformation(line - 1).getLength();
                 // should be fine for first and last lines in the doc as well
                 String replacementText = indent + "type: object";
-                document.replace(endOfCurrLine, 0, TextUtilities.getDefaultLineDelimiter(document) + replacementText);
-                return new Region(endOfCurrLine + 1, replacementText.length());
+                String delim = TextUtilities.getDefaultLineDelimiter(document);
+                document.replace(endOfCurrLine, 0, delim + replacementText);
+                return new Region(endOfCurrLine + delim.length(), replacementText.length());
             } catch (BadLocationException e) {
                 throw new CoreException(createStatus(e, "Cannot process the IMarker"));
             }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
@@ -69,7 +69,7 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
         }
 
         @Override
-        protected void processFix(IDocument document, IMarker marker) throws CoreException {
+        public void processFix(IDocument document, IMarker marker) throws CoreException {
             int line = (int) marker.getAttribute(IMarker.LINE_NUMBER);
             try {
                 String indent = getIndent(document, line);
@@ -99,7 +99,7 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
 
     public abstract static class TextDocumentMarkerResolution implements IMarkerResolution {
 
-        protected abstract void processFix(IDocument document, IMarker marker) throws CoreException;
+        public abstract void processFix(IDocument document, IMarker marker) throws CoreException;
 
         public void run(IMarker marker) {
             try {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
@@ -23,6 +23,8 @@ import org.eclipse.core.runtime.Status;
 import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
 import org.eclipse.jface.text.TextUtilities;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.IMarkerResolution;
@@ -69,7 +71,7 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
         }
 
         @Override
-        public void processFix(IDocument document, IMarker marker) throws CoreException {
+        public IRegion processFix(IDocument document, IMarker marker) throws CoreException {
             int line = (int) marker.getAttribute(IMarker.LINE_NUMBER);
             try {
                 String indent = getIndent(document, line);
@@ -77,8 +79,9 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
                 int endOfCurrLine = document.getLineInformation(line - 1).getOffset()
                         + document.getLineInformation(line - 1).getLength();
                 // should be fine for first and last lines in the doc as well
-                document.replace(endOfCurrLine, 0,
-                        TextUtilities.getDefaultLineDelimiter(document) + indent + "type: object");
+                String replacementText = indent + "type: object";
+                document.replace(endOfCurrLine, 0, TextUtilities.getDefaultLineDelimiter(document) + replacementText);
+                return new Region(endOfCurrLine + 1, replacementText.length());
             } catch (BadLocationException e) {
                 throw new CoreException(createStatus(e, "Cannot process the IMarker"));
             }
@@ -99,29 +102,31 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
 
     public abstract static class TextDocumentMarkerResolution implements IMarkerResolution {
 
-        public abstract void processFix(IDocument document, IMarker marker) throws CoreException;
+        /**
+         * @return IRegion to be selected in the editor, can be null
+         * @throws CoreException
+         */
+        public abstract IRegion processFix(IDocument document, IMarker marker) throws CoreException;
 
         public void run(IMarker marker) {
             try {
-                IDocument document = getDocument(marker);
-                processFix(document, marker);
+                IResource resource = marker.getResource();
+                if (resource.getType() != IResource.FILE) {
+                    throw new CoreException(createStatus(null, "The editor is not a File: " + resource.getName()));
+                }
+                IFile file = (IFile) resource;
+                ITextEditor editor = openTextEditor(file);
+                IDocument document = editor.getDocumentProvider().getDocument(new FileEditorInput(file));
+                if (document == null) {
+                    throw new CoreException(createStatus(null, "The document is null"));
+                }
+                IRegion region = processFix(document, marker);
+                if (region != null) {
+                    editor.selectAndReveal(region.getOffset(), region.getLength());
+                }
             } catch (CoreException e) {
                 Activator.getDefault().getLog().log(e.getStatus());
             }
-        }
-
-        protected IDocument getDocument(IMarker marker) throws CoreException {
-            IResource resource = marker.getResource();
-            if (resource.getType() != IResource.FILE) {
-                throw new CoreException(createStatus(null, "The editor is not a File: " + resource.getName()));
-            }
-            IFile file = (IFile) resource;
-            ITextEditor editor = openTextEditor(file);
-            IDocument document = editor.getDocumentProvider().getDocument(new FileEditorInput(file));
-            if (document == null) {
-                throw new CoreException(createStatus(null, "The document is null"));
-            }
-            return document;
         }
 
         protected ITextEditor openTextEditor(IFile file) throws CoreException {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/validation/QuickFixer.java
@@ -74,8 +74,8 @@ public class QuickFixer implements IMarkerResolutionGenerator2 {
             try {
                 String indent = getIndent(document, line);
                 // getLineOffset() is zero-based, and imarkerLine is one-based.
-                int endOfCurrLine = document.getLineInformation(line-1).getOffset()
-                        + document.getLineInformation(line-1).getLength();
+                int endOfCurrLine = document.getLineInformation(line - 1).getOffset()
+                        + document.getLineInformation(line - 1).getLength();
                 // should be fine for first and last lines in the doc as well
                 document.replace(endOfCurrLine, 0,
                         TextUtilities.getDefaultLineDelimiter(document) + indent + "type: object");


### PR DESCRIPTION
Now, markers with a QuickFix have a little bulb icon:
<img width="216" alt="screen shot 2017-04-19 at 9 05 57 pm" src="https://cloud.githubusercontent.com/assets/644582/25208717/657df7d2-2544-11e7-95b0-ea033cf2e342.png">

Ctrl+1 (Cmd+1 on Mac) now shows available quick fixes, the added text is now selected:
![quick_fix](https://cloud.githubusercontent.com/assets/644582/25208740/8c051804-2544-11e7-88b4-c55844781e33.gif)
