### PR TITLE
Add the "experimental" note to the New OpenAPI v3 wizard and prefs

### DIFF
--- a/com.reprezen.swagedit.openapi3/plugin.xml
+++ b/com.reprezen.swagedit.openapi3/plugin.xml
@@ -40,7 +40,7 @@
             class="com.reprezen.swagedit.openapi3.editor.wizard.NewOpenApiV3SpecWizard"
             icon="icons/OpenAPI_32.png"
             id="com.reprezen.swagedit.openapi3.editor.wizard.NewOpenApiV3SpecWizard"
-            name="OpenAPI v3 Spec">
+            name="OpenAPI v3 Spec (experimental)">
             <description>Create an OpenAPI v3 spec</description>
       </wizard>
    </extension>

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/preferences/OpenApi3PreferencePage.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/preferences/OpenApi3PreferencePage.java
@@ -10,26 +10,14 @@
  *******************************************************************************/
 package com.reprezen.swagedit.openapi3.preferences;
 
-import org.eclipse.jface.preference.FieldEditorPreferencePage;
-import org.eclipse.ui.IWorkbench;
-import org.eclipse.ui.IWorkbenchPreferencePage;
-
+import com.reprezen.swagedit.core.preferences.KaizenPreferencePage;
 import com.reprezen.swagedit.openapi3.Activator;
 
-public class OpenApi3PreferencePage extends FieldEditorPreferencePage implements IWorkbenchPreferencePage {
+public class OpenApi3PreferencePage extends KaizenPreferencePage {
 
     public OpenApi3PreferencePage() {
-        super(GRID);
-        setDescription("OpenAPI v3 Preferences");
+        setDescription("KaiZen OpenAPI Editor preferences for OpenAPI v3 (experimental)");
         setPreferenceStore(Activator.getDefault().getPreferenceStore());
-    }
-
-    @Override
-    public void init(IWorkbench workbench) {
-     }
-
-    @Override
-    protected void createFieldEditors() {
     }
 
 }


### PR DESCRIPTION
* Add " (experimental)" after the OpenAPI v3 Spec label in the File >
New Wizard, so the File > New option is "OpenAPI v3 Spec (experimental)"
<img width="278" alt="screen shot 2017-05-08 at 4 44 00 pm" src="https://cloud.githubusercontent.com/assets/644582/25824596/fb2a6afe-340d-11e7-8232-48e3c5fce98a.png">

* Add " (experimental)" in the preferences page, so the `Preferences >
KaiZen > OpenAPI v3` page description is "KaiZen OpenAPI Editor
preferences for OpenAPI v3 (experimental)"
<img width="654" alt="screen shot 2017-05-08 at 4 44 14 pm" src="https://cloud.githubusercontent.com/assets/644582/25824608/0b3d5cd0-340e-11e7-8c79-687e98b4d318.png">


