### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <img src="https://cdn2.hubspot.net/hubfs/597611/Assets_Swagger/KZOE.png" alt="KaiZen OpenAPI Editor Logo" height="50%" width="50%"/>
+
 # KaiZen OpenAPI Editor for Eclipse
 
 KaiZen OpenAPI Editor is an Eclipse Editor for the [Swagger](http://swagger.io) API Description Language, now known as the [OpenAPI Specification](http://openapis.org). The editor supports Swagger-OpenAPI version 2.0, with OpenAPI 3.0 support coming soon.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <img src="https://cdn2.hubspot.net/hubfs/597611/Assets_Swagger/KZOE.png" alt="KaiZen OpenAPI Editor Logo" height="50%" width="50%"/>
 # KaiZen OpenAPI Editor for Eclipse
 
-KaiZen OpenAPI Editor is an Eclipse Editor for the [Swagger](http://swagger.io) API Description Language, now known as the [OpenAPI Specification](http://openapis.org). The editor supports Swagger-OpenAPI version 2.0, with OpenAPI 3.0 support coming soon. 
+KaiZen OpenAPI Editor is an Eclipse Editor for the [Swagger](http://swagger.io) API Description Language, now known as the [OpenAPI Specification](http://openapis.org). The editor supports Swagger-OpenAPI version 2.0, with OpenAPI 3.0 support coming soon.
 
-KaiZen Editor was developed for [RepreZen API Studio](http://reprezen.com/swagger-tools), a comprehensive solution for API modeling, documentation, visualization, testing and code generation, built on Eclipse.
+KaiZen Editor, formerly known as SwagEdit, was developed for [RepreZen API Studio](http://reprezen.com/swagger-tools), a comprehensive solution for API modeling, documentation, visualization, testing and code generation, built on Eclipse.
 
 We welcome your suggestions and contributions!
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
-# SwagEdit - Eclipse Editor for Swagger–OpenAPI
+<img src="https://cdn2.hubspot.net/hubfs/597611/Assets_Swagger/KZOE.png" alt="KaiZen OpenAPI Editor Logo" height="50%" width="50%"/>
+# KaiZen OpenAPI Editor for Eclipse
 
-SwagEdit is an Eclipse Editor for the [Swagger](http://swagger.io) API Description Language, now known as the [OpenAPI Specification](http://openapis.org).
+KaiZen OpenAPI Editor is an Eclipse Editor for the [Swagger](http://swagger.io) API Description Language, now known as the [OpenAPI Specification](http://openapis.org). The editor supports Swagger-OpenAPI version 2.0, with OpenAPI 3.0 support coming soon. 
 
-SwagEdit was developed for [RepreZen API Studio](http://reprezen.com/swagger-tools), a comprehensive solution for API modeling, documentation, visualization, testing and code generation, built on Eclipse. Swagger–OpenAPI.
+KaiZen Editor was developed for [RepreZen API Studio](http://reprezen.com/swagger-tools), a comprehensive solution for API modeling, documentation, visualization, testing and code generation, built on Eclipse.
 
 We welcome your suggestions and contributions!
 
@@ -35,34 +36,37 @@ Quick Outline can be invoked with Ctrl+O. Similar to code assist for references,
 Outline View reflects the open Swagger model:  
 <img src="http://i.imgur.com/iv49CLn.png" alt="Navigation_to_references" width="400">
 
-## Install SwagEdit
+## Installing KaiZen OpenAPI Editor
+
+### Installing from Eclipse Marketplace
+The easiest way to install KaiZen Editor into an Eclipse IDE is using the [Eclipse Marketplace solution](https://marketplace.eclipse.org/content/kaizen-openapi-editor). You can drag-and-drop the Install button into your Eclipse IDE, or use the built-in Eclipse Marketplace Client.
+
 ### Via an update site 
-You can now install SwagEdit into your Eclipse by clicking on `Help > Install New Software... > Add...`
+You can now install KaiZen OpenAPI Editor into your Eclipse by clicking on `Help > Install New Software... > Add...`
 This will show a dialog box from where you can select the location of the update site.
 Use the update site from [http://products.modelsolv.com/swagedit/0.1.0/latest/](http://products.modelsolv.com/swagedit/0.1.0/latest/) as URL.
 
-### Eclipse Marketplace
-SwagEdit is not on Marketplace yet, but we are working on it, see [issue 65](https://github.com/RepreZen/SwagEdit/issues/65)
-
-## User Documentation
-Read more about SwagEdit features on http://www.reprezen.com/swagger-tools
+### In RepreZen API Studio
+KaiZen Editor is fully functional inside RepreZen API Studio, which adds live documentation and diagram views, sandbox testing with the built-in mock service and Swagger-UI, powerful code generation, and other features. See the RepreZen API Studio [video and feature tour](http://www.reprezen.com/swagger-tools) to learn more and download a free trial.
 
 ## Troubleshooting
 See [Troubleshooting](https://github.com/RepreZen/SwagEdit/blob/master/TROUBLESHOOTING.md)
 
-## Contributing to SwagEdit
+## Contributing to KaiZen OpenAPI Editor
 We welcome contributions - documentation, bug reports or bug fixes.
-If you are interested in contributing to SwagEdit please see [Development Page](https://github.com/RepreZen/SwagEdit/blob/master/DEVELOPERS_GUIDE.md), we created a list of [good first bugs](https://github.com/RepreZen/SwagEdit/labels/Good%20First%20Bug) that are relatively easy to fix.
+If you are interested in contributing to KaiZen Editor please see the [Developer's Guide](https://github.com/RepreZen/SwagEdit/blob/master/DEVELOPERS_GUIDE.md). 
+
+We also created a list of [good first bugs](https://github.com/RepreZen/SwagEdit/labels/Good%20First%20Bug)
+that are relatively easy to fix.
 
 ## License
-SwagEdit is provided under the Eclipse Public License (https://www.eclipse.org/legal/epl-v10.html)
+KaiZen OpenAPI Editor is provided under the Eclipse Public License (https://www.eclipse.org/legal/epl-v10.html)
 
-## Video: SwagEdit in RepreZen API Studio
-RepreZen API Studio is built on top of SwagEdit and provides more cool features, such as mock service and live views. Watch :vhs: here: 
+## Video: KaiZen Editor in RepreZen API Studio
 
 [![Editing Swagger-OpenAPI in RepreZen API Studio](http://img.youtube.com/vi/KX_tHp_KQkE/0.jpg)](https://www.youtube.com/watch?v=KX_tHp_KQkE)
 
-_**Note:** SwagEdit includes code assist, real-time validation, syntax highlighting, and outline view.<br/>
+_**Note:** KaiZen Editor includes code assist, real-time validation, syntax highlighting, and outline view.<br/>
 [Eclipse Color Theme](https://marketplace.eclipse.org/content/eclipse-color-theme) and [EditBox](http://marketplace.eclipse.org/content/nodeclipse-editbox-background-colors-themes-highlight-code-blocks-c-java-javascript-python) are available as separate plugins.<br/>
-[RepreZen API Studio](http://reprezen.com/swagger-tools) includes the mock service, live Swagger-UI & other features that are not part of SwagEdit._
+[RepreZen API Studio](http://reprezen.com/swagger-tools) includes the mock service, live Swagger-UI & other features that are not part of KaiZen Editor._
 

--- a/README.md
+++ b/README.md
@@ -22,8 +22,15 @@ Keywords and values:
 <img src="http://i.imgur.com/3uZ5bQa.gif" alt="CodeAssist_keys_and_values" width="400">
 
 ### Code Assist for References
-Code assist for references has several scopes which can be viewed in sequence using the assigned hotkey (`Ctrl`+`Space` on Windows). The first scope shows only elements from the current document; the second expands it to elements from the containing project; and the third shows elements from the entire workspace:  
+Code assist for references has several scopes which can be viewed in sequence by pressing `Ctrl`+`Space` repeatedly:
+
+* The first scope shows only elements from the current document.
+* The second expands it to elements from the containing project.
+* The third shows elements from the entire workspace.
+
 <img src="http://i.imgur.com/P0IWIEt.gif" alt="CodeAssist_for_references" width="400">
+
+Pressing the hotkey a fourth time starts the cycle over again, with document scope.
 
 ### Navigation to a Reference
 You can navigate to a reference using `Ctrl`+`Click`:  
@@ -38,9 +45,10 @@ Outline View shows the contents of the active OpenAPI spec:
 <img src="http://i.imgur.com/iv49CLn.png" alt="Navigation_to_references" width="400">
 
 ## Installing KaiZen OpenAPI Editor
+KaiZen OpenAPI Editor requires Eclipse Mars.2 or higher.
 
 ### Installing from Eclipse Marketplace
-The [Eclipse Marketplace solution](https://marketplace.eclipse.org/content/kaizen-openapi-editor) is the easiest way to install KaiZen Editor into an Eclipse IDE. You can drag-and-drop the Install button into your Eclipse IDE, or use the built-in Eclipse Marketplace Client.
+The [Eclipse Marketplace solution](https://marketplace.eclipse.org/content/kaizen-openapi-editor) is the easiest way to install KaiZen Editor into an Eclipse IDE. You can drag-and-drop the Install button from the browser into your Eclipse IDE, or use the built-in Eclipse Marketplace Client.
 
 ### Installing from the Update Site 
 You can install KaiZen OpenAPI Editor into your Eclipse IDE by clicking on `Help > Install New Software... > Add...`

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # KaiZen OpenAPI Editor for Eclipse
 
-KaiZen OpenAPI Editor is an Eclipse Editor for the [Swagger](http://swagger.io) API Description Language, now known as the [OpenAPI Specification](http://openapis.org). The editor supports Swagger-OpenAPI version 2.0, with OpenAPI 3.0 support coming soon.
+KaiZen OpenAPI Editor is an Eclipse editor for the [Swagger](http://swagger.io) API Description Language, now known as the [OpenAPI Specification](http://openapis.org). The editor supports Swagger-OpenAPI version 2.0, with OpenAPI 3.0 support coming soon.
 
 KaiZen Editor, formerly known as SwagEdit, was developed for [RepreZen API Studio](http://reprezen.com/swagger-tools), a comprehensive solution for API modeling, documentation, visualization, testing and code generation, built on Eclipse.
 
@@ -22,46 +22,46 @@ Keywords and values:
 <img src="http://i.imgur.com/3uZ5bQa.gif" alt="CodeAssist_keys_and_values" width="400">
 
 ### Code Assist for References
-Code assist for references has several scopes which can be switched by Ctrl+click. The first scope is shows only elements from the current model, the second expands it to the elements from the containing project, and the third shows elements from the entire workspace:  
+Code assist for references has several scopes which can be viewed in sequence using the assigned hotkey (`Ctrl`+`Space` on Windows). The first scope shows only elements from the current document; the second expands it to elements from the containing project; and the third shows elements from the entire workspace:  
 <img src="http://i.imgur.com/P0IWIEt.gif" alt="CodeAssist_for_references" width="400">
 
 ### Navigation to a Reference
-You can navigate to a reference using Ctrl+Click:  
+You can navigate to a reference using `Ctrl`+`Click`:  
 <img src="http://i.imgur.com/7WpuV3K.gif" alt="Navigation_to_references" width="400">
 
 ### Quick Outline
-Quick Outline can be invoked with Ctrl+O. Similar to code assist for references, it has three scopes: model, project, and project. It also allows filtering:    
+Quick Outline can be invoked with `Ctrl`+`o`. Similar to code assist for references, it has three scopes: model, project, and workspace. It also allows filtering:    
 <img src="http://i.imgur.com/jvcoooa.gif" alt="Navigation_to_references" width="400">
 
 ### Outline
-Outline View reflects the open Swagger model:  
+Outline View shows the contents of the active OpenAPI spec:  
 <img src="http://i.imgur.com/iv49CLn.png" alt="Navigation_to_references" width="400">
 
 ## Installing KaiZen OpenAPI Editor
 
 ### Installing from Eclipse Marketplace
-The easiest way to install KaiZen Editor into an Eclipse IDE is using the [Eclipse Marketplace solution](https://marketplace.eclipse.org/content/kaizen-openapi-editor). You can drag-and-drop the Install button into your Eclipse IDE, or use the built-in Eclipse Marketplace Client.
+The [Eclipse Marketplace solution](https://marketplace.eclipse.org/content/kaizen-openapi-editor) is the easiest way to install KaiZen Editor into an Eclipse IDE. You can drag-and-drop the Install button into your Eclipse IDE, or use the built-in Eclipse Marketplace Client.
 
-### Via an update site 
-You can now install KaiZen OpenAPI Editor into your Eclipse by clicking on `Help > Install New Software... > Add...`
-This will show a dialog box from where you can select the location of the update site.
-Use the update site from [http://products.modelsolv.com/swagedit/0.1.0/latest/](http://products.modelsolv.com/swagedit/0.1.0/latest/) as URL.
+### Installing from the Update Site 
+You can install KaiZen OpenAPI Editor into your Eclipse IDE by clicking on `Help > Install New Software... > Add...`
+This will show a dialog box where you can select the location of the update site.
+Use the update site from [http://products.modelsolv.com/swagedit/0.1.0/latest/](http://products.modelsolv.com/swagedit/0.1.0/latest/) as the URL.
 
-### In RepreZen API Studio
+### Installing with RepreZen API Studio
 KaiZen Editor is fully functional inside RepreZen API Studio, which adds live documentation and diagram views, sandbox testing with the built-in mock service and Swagger-UI, powerful code generation, and other features. See the RepreZen API Studio [video and feature tour](http://www.reprezen.com/swagger-tools) to learn more and download a free trial.
 
 ## Troubleshooting
-See [Troubleshooting](https://github.com/RepreZen/SwagEdit/blob/master/TROUBLESHOOTING.md)
+See the [Troubleshooting Guide](https://github.com/RepreZen/SwagEdit/blob/master/TROUBLESHOOTING.md) for solutions to common problems.
 
 ## Contributing to KaiZen OpenAPI Editor
 We welcome contributions - documentation, bug reports or bug fixes.
-If you are interested in contributing to KaiZen Editor please see the [Developer's Guide](https://github.com/RepreZen/SwagEdit/blob/master/DEVELOPERS_GUIDE.md). 
+If you are interested in contributing to KaiZen Editor, please see the [Developer's Guide](https://github.com/RepreZen/SwagEdit/blob/master/DEVELOPERS_GUIDE.md). 
 
 We also created a list of [good first bugs](https://github.com/RepreZen/SwagEdit/labels/Good%20First%20Bug)
 that are relatively easy to fix.
 
 ## License
-KaiZen OpenAPI Editor is provided under the Eclipse Public License (https://www.eclipse.org/legal/epl-v10.html)
+KaiZen OpenAPI Editor is provided under the [Eclipse Public License v1.0](https://www.eclipse.org/legal/epl-v10.html)
 
 ## Video: KaiZen Editor in RepreZen API Studio
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The [Eclipse Marketplace solution](https://marketplace.eclipse.org/content/kaize
 ### Installing from the Update Site 
 You can install KaiZen OpenAPI Editor into your Eclipse IDE by clicking on `Help > Install New Software... > Add...`
 This will show a dialog box where you can select the location of the update site.
-Use the update site from [http://products.modelsolv.com/swagedit/0.1.0/latest/](http://products.modelsolv.com/swagedit/0.1.0/latest/) as the URL.
+Use the update site from (http://products.reprezen.com/swagedit/latest/) as the URL.
 
 ### Installing with RepreZen API Studio
 KaiZen Editor is fully functional inside RepreZen API Studio, which adds live documentation and diagram views, sandbox testing with the built-in mock service and Swagger-UI, powerful code generation, and other features. See the RepreZen API Studio [video and feature tour](http://www.reprezen.com/swagger-tools) to learn more and download a free trial.


### PR DESCRIPTION
These are changes to the README to complete the KZOE rename, and  generally bring the intro up to date.

@tfesenko, I have a few questions:
* The readme refers to an update site on products.modelsolv.com.  That update site seems to have been updated in mid-April, so it's not completely out of date.  But do we now want to start directing people to the products.reprezen.com update site, which Marketplace is pointing to?
* I don't see any mention in this readme as to which versions of Eclipse are supported.  Should we say Mars.2 or later, same as with RepreZen API Studio?