### PR TITLE
ZEN-3440 - QuickOutline and external preferences: filter files by content type

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonContentAssistProcessor.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonContentAssistProcessor.java
@@ -85,9 +85,9 @@ public abstract class JsonContentAssistProcessor extends TemplateCompletionProce
 
     private String[] textMessages;
     
-	public JsonContentAssistProcessor(ContentAssistant ca) {
+	public JsonContentAssistProcessor(ContentAssistant ca, String fileContentType) {
 		this(ca, new JsonProposalProvider(),
-				new JsonReferenceProposalProvider(ContextType.emptyContentTypeCollection()));
+				new JsonReferenceProposalProvider(ContextType.emptyContentTypeCollection(), fileContentType));
 	}
     
     public JsonContentAssistProcessor(ContentAssistant ca, JsonProposalProvider proposalProvider, JsonReferenceProposalProvider referenceProposalProvider) {

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
@@ -10,7 +10,6 @@
  *******************************************************************************/
 package com.reprezen.swagedit.core.assist;
 
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
@@ -26,9 +25,8 @@ import com.google.common.collect.Lists;
 import com.reprezen.swagedit.core.json.references.JsonDocumentManager;
 import com.reprezen.swagedit.core.utils.DocumentUtils;
 import com.reprezen.swagedit.core.utils.SwaggerFileFinder;
-import com.reprezen.swagedit.core.utils.URLUtils;
 import com.reprezen.swagedit.core.utils.SwaggerFileFinder.Scope;
-import com.reprezen.swagedit.core.validation.SwaggerError;
+import com.reprezen.swagedit.core.utils.URLUtils;
 import com.reprezen.swagedit.core.validation.ValidationUtil;
 
 /**
@@ -38,13 +36,11 @@ public class JsonReferenceProposalProvider {
 
     private final JsonDocumentManager manager = JsonDocumentManager.getInstance();
 	private final ContextTypeCollection contextTypes;
+	private final String fileContentType;
     
-    public JsonReferenceProposalProvider(ContextTypeCollection contextTypes) {
+    public JsonReferenceProposalProvider(ContextTypeCollection contextTypes, String fileContentType) {
 		this.contextTypes = contextTypes;
-	}
-    
-    public JsonReferenceProposalProvider(Iterable<ContextType> contextTypes) {
-		this(ContextType.newContentTypeCollection(contextTypes));
+		this.fileContentType = fileContentType;
 	}
 
     protected IFile getActiveFile() {
@@ -80,7 +76,7 @@ public class JsonReferenceProposalProvider {
         if (scope == Scope.LOCAL) {
             proposals.addAll(collectProposals(doc, type.value(), null));
         } else {
-            final SwaggerFileFinder fileFinder = new SwaggerFileFinder();
+            final SwaggerFileFinder fileFinder = new SwaggerFileFinder(fileContentType);
 
             for (IFile file : fileFinder.collectFiles(scope, currentFile)) {
                 IPath relative = file.equals(currentFile) ? null : file.getFullPath().makeRelativeTo(basePath);

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/JsonSourceViewerConfiguration.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/JsonSourceViewerConfiguration.java
@@ -79,7 +79,7 @@ public abstract class JsonSourceViewerConfiguration extends YEditSourceViewerCon
     }
     
     protected JsonContentAssistProcessor createContentAssistProcessor(ContentAssistant ca) {
-    	return new JsonContentAssistProcessor(ca){
+    	return new JsonContentAssistProcessor(ca, null){
 
 			@Override
 			protected TemplateStore getTemplateStore() {
@@ -162,10 +162,12 @@ public abstract class JsonSourceViewerConfiguration extends YEditSourceViewerCon
         return assistant;
     }
 
-    private IInformationControlCreator getOutlineInformationControlCreator() {
+    abstract protected IInformationControlCreator getOutlineInformationControlCreator();
+   
+    protected IInformationControlCreator getOutlineInformationControlCreator(final String fileContentType) {
         return new IInformationControlCreator() {
             public IInformationControl createInformationControl(Shell parent) {
-                QuickOutline dialog = new QuickOutline(parent, getEditor()) {
+                QuickOutline dialog = new QuickOutline(parent, getEditor(), fileContentType) {
 
 					@Override
 					protected CompositeSchema getSchema() {

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/outline/QuickOutline.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/outline/QuickOutline.java
@@ -75,11 +75,14 @@ public abstract class QuickOutline extends PopupDialog
     private TriggerSequence triggerSequence;
     private String bindingKey;
     private Timer filterTimer = null;
-    
+
+	private final String fileContentType;
+
     abstract protected CompositeSchema getSchema();
 
-    public QuickOutline(Shell parent, JsonEditor editor) {
+    public QuickOutline(Shell parent, JsonEditor editor, String fileContentType) {
         super(parent, PopupDialog.INFOPOPUPRESIZE_SHELLSTYLE, true, true, true, true, true, null, null);
+		this.fileContentType = fileContentType;
 
         IBindingService bindingService = (IBindingService) PlatformUI.getWorkbench().getAdapter(IBindingService.class);
         this.bindingKey = bindingService.getBestActiveBindingFormattedFor(COMMAND_ID);
@@ -170,7 +173,7 @@ public abstract class QuickOutline extends PopupDialog
 
     protected void handleMultiView() {
         currentScope = currentScope.next();
-        SwaggerFileFinder fileFinder = new SwaggerFileFinder();
+        SwaggerFileFinder fileFinder = new SwaggerFileFinder(fileContentType);
         IEditorInput input = editor.getEditorInput();
 
         IFile currentFile = null;

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/utils/SwaggerFileFinder.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/utils/SwaggerFileFinder.java
@@ -26,6 +26,12 @@ import com.google.common.collect.Lists;
  * Utility class used to located swagger files depending on a scope.
  */
 public class SwaggerFileFinder {
+	
+	private final String fileContentType;
+
+	public SwaggerFileFinder(String fileContentType) {
+		this.fileContentType = fileContentType;
+	}
 
     /**
      * Enumeration use to indicate where the finder should locate the swagger files.
@@ -101,7 +107,7 @@ public class SwaggerFileFinder {
     }
 
     protected Iterable<IFile> collectFiles(IContainer parent, IFile currentFile) {
-        final FileVisitor visitor = new FileVisitor(currentFile);
+        final FileVisitor visitor = new FileVisitor(currentFile, fileContentType);
 
         try {
             parent.accept(visitor, 0);
@@ -115,9 +121,11 @@ public class SwaggerFileFinder {
 
         private final List<IFile> files;
         private final IFile currentFile;
+		private final String fileContentType;
 
-        public FileVisitor(IFile currentFile) {
+        public FileVisitor(IFile currentFile, String fileContentType) {
             this.currentFile = currentFile;
+			this.fileContentType = fileContentType;
             this.files = new ArrayList<IFile>();
 
             if (currentFile != null) {
@@ -133,7 +141,10 @@ public class SwaggerFileFinder {
                 if (!proxy.isDerived()) {
                     IFile file = (IFile) proxy.requestResource();
                     if (!file.equals(currentFile)) {
-                        files.add(file);
+						String currFileType = file.getContentDescription().getContentType().getId();
+						if (fileContentType == null || fileContentType.equals(currFileType)) {
+							files.add(file);
+						}
                     }
                 }
             } else if (proxy.getType() == IResource.FOLDER

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -12,11 +12,12 @@ package com.reprezen.swagedit.openapi3.assist;
 
 import com.google.common.collect.Lists;
 import com.reprezen.swagedit.core.assist.JsonReferenceProposalProvider;
+import com.reprezen.swagedit.openapi3.editor.OpenApi3ContentDescriber;
 
 public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProvider {
 
 	public OpenApi3ReferenceProposalProvider() {
-		super(OPEN_API3_CONTEXT_TYPES);
+		super(OPEN_API3_CONTEXT_TYPES, OpenApi3ContentDescriber.CONTENT_TYPE_ID);
 	}
 
 	protected static final String SCHEMA_DEFINITION_REGEX = "^/components/schemas/(\\w+/)+\\$ref|.*schema/(\\w+/)?\\$ref";

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3ContentDescriber.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3ContentDescriber.java
@@ -13,6 +13,8 @@ package com.reprezen.swagedit.openapi3.editor;
 import com.reprezen.swagedit.core.editor.TextContentDescriber;
 
 public class OpenApi3ContentDescriber extends TextContentDescriber {
+	
+	public static final String CONTENT_TYPE_ID = "com.reprezen.swagedit.contenttype.openapi3.yaml";
 
     @Override
     protected boolean isSupported(String content) {

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3ContentDescriber.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3ContentDescriber.java
@@ -10,16 +10,19 @@
  *******************************************************************************/
 package com.reprezen.swagedit.openapi3.editor;
 
+import java.util.regex.Pattern;
+
 import com.reprezen.swagedit.core.editor.TextContentDescriber;
 
 public class OpenApi3ContentDescriber extends TextContentDescriber {
 	
 	public static final String CONTENT_TYPE_ID = "com.reprezen.swagedit.contenttype.openapi3.yaml";
+	private final Pattern openApiV3Regex = Pattern.compile(".*openapi:\\s+[\"']3\\.0\\..+", Pattern.DOTALL);
 
     @Override
     protected boolean isSupported(String content) {
         // should support arbitrary patch versions, e.g. `openapi: "3.0.0-RC0"`
-        return content.contains("openapi: \"3.0.") || content.contains("openapi: '3.0");
+        return openApiV3Regex.matcher(content).matches();
     }
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
@@ -1,6 +1,7 @@
 package com.reprezen.swagedit.openapi3.editor;
 
 import org.dadacoalition.yedit.editor.YEditSourceViewerConfiguration;
+import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
 import org.eclipse.jface.text.hyperlink.IHyperlinkDetector;
 import org.eclipse.jface.text.hyperlink.URLHyperlinkDetector;
@@ -48,6 +49,11 @@ public class OpenApi3Editor extends JsonEditor {
 		@Override
 		protected CompositeSchema getSchema() {
 			return Activator.getDefault().getSchema();
+		}
+
+		@Override
+		protected IInformationControlCreator getOutlineInformationControlCreator() {
+			return getOutlineInformationControlCreator(OpenApi3ContentDescriber.CONTENT_TYPE_ID);
 		}
 
 	}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerReferenceProposalProvider.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/assist/SwaggerReferenceProposalProvider.java
@@ -12,6 +12,7 @@ package com.reprezen.swagedit.assist;
 
 import com.google.common.collect.Lists;
 import com.reprezen.swagedit.core.assist.JsonReferenceProposalProvider;
+import com.reprezen.swagedit.editor.SwaggerContentDescriber;
 
 /**
  * Completion proposal provider for JSON references.
@@ -19,7 +20,7 @@ import com.reprezen.swagedit.core.assist.JsonReferenceProposalProvider;
 public class SwaggerReferenceProposalProvider extends JsonReferenceProposalProvider {
 
 	public SwaggerReferenceProposalProvider() {
-		super(SWAGGER_CONTEXT_TYPES);
+		super(SWAGGER_CONTEXT_TYPES, SwaggerContentDescriber.CONTENT_TYPE_ID);
 	}
 
 	protected static final String SCHEMA_DEFINITION_REGEX = "^/definitions/(\\w+/)+\\$ref|.*schema/(\\w+/)?\\$ref";

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerContentDescriber.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerContentDescriber.java
@@ -10,15 +10,19 @@
  *******************************************************************************/
 package com.reprezen.swagedit.editor;
 
+import java.util.regex.Pattern;
+
 import com.reprezen.swagedit.core.editor.TextContentDescriber;
 
 public class SwaggerContentDescriber extends TextContentDescriber {
 	
 	public static final String CONTENT_TYPE_ID = "com.reprezen.swagedit.contenttype.swagger.yaml";
 
+    private final Pattern swaggerV2Regex = Pattern.compile(".*swagger:\\s+([\"'])2\\.0\\1.+", Pattern.DOTALL);
+
     @Override
     protected boolean isSupported(String content) {
-        return content.contains("swagger: \"2.0\"") || content.contains("swagger: '2.0'");
+        return swaggerV2Regex.matcher(content).matches();
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerContentDescriber.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerContentDescriber.java
@@ -13,6 +13,8 @@ package com.reprezen.swagedit.editor;
 import com.reprezen.swagedit.core.editor.TextContentDescriber;
 
 public class SwaggerContentDescriber extends TextContentDescriber {
+	
+	public static final String CONTENT_TYPE_ID = "com.reprezen.swagedit.contenttype.swagger.yaml";
 
     @Override
     protected boolean isSupported(String content) {

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerSourceViewerConfiguration.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerSourceViewerConfiguration.java
@@ -1,6 +1,7 @@
 package com.reprezen.swagedit.editor;
 
 import org.eclipse.jface.preference.IPreferenceStore;
+import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
 import org.eclipse.jface.text.hyperlink.IHyperlinkDetector;
 import org.eclipse.jface.text.hyperlink.URLHyperlinkDetector;
@@ -34,6 +35,11 @@ public class SwaggerSourceViewerConfiguration extends JsonSourceViewerConfigurat
 	@Override
 	protected CompositeSchema getSchema() {
 		return com.reprezen.swagedit.Activator.getDefault().getSchema();
+	}
+
+	@Override
+	protected IInformationControlCreator getOutlineInformationControlCreator() {
+		return getOutlineInformationControlCreator(SwaggerContentDescriber.CONTENT_TYPE_ID);
 	}
 
 }


### PR DESCRIPTION
[Targeting topic/openapi3, replaces PR #280]

QuickOutline and code-assist for references can show elements from v2 models for v3 and vice versa, see https://modelsolv.atlassian.net/browse/ZEN-3509?focusedCommentId=40220