### PR TITLE
#289: Open API v3: Content Assist for References

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
@@ -135,7 +135,6 @@ public class JsonReferenceProposalProvider {
     	}
 		
 		public ContextType get(String path) {
-		    System.out.println("TANYA: " + path);
 			if (Strings.emptyToNull(path) == null) {
 				return ContextType.UNKNOWN;
 			}

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
@@ -135,6 +135,7 @@ public class JsonReferenceProposalProvider {
     	}
 		
 		public ContextType get(String path) {
+		    System.out.println("TANYA: " + path);
 			if (Strings.emptyToNull(path) == null) {
 				return ContextType.UNKNOWN;
 			}

--- a/com.reprezen.swagedit.openapi3.tests/.classpath
+++ b/com.reprezen.swagedit.openapi3.tests/.classpath
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<classpath>
+	<classpathentry exported="true" kind="lib" path="lib/mockito-core-1.10.19.jar"/>
+	<classpathentry exported="true" kind="lib" path="lib/objenesis-2.1.jar"/>
+	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7"/>
+	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
+	<classpathentry kind="src" path="src"/>
+	<classpathentry kind="src" path="xtend-gen"/>
+	<classpathentry kind="output" path="target/classes"/>
+</classpath>

--- a/com.reprezen.swagedit.openapi3.tests/.project
+++ b/com.reprezen.swagedit.openapi3.tests/.project
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>com.reprezen.swagedit.openapi3.tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.xtext.ui.shared.xtextBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.jdt.core.javabuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.ManifestBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.pde.SchemaBuilder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+		<nature>org.eclipse.pde.PluginNature</nature>
+		<nature>org.eclipse.jdt.core.javanature</nature>
+		<nature>org.eclipse.xtext.ui.shared.xtextNature</nature>
+	</natures>
+</projectDescription>

--- a/com.reprezen.swagedit.openapi3.tests/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit.openapi3.tests/META-INF/MANIFEST.MF
@@ -1,0 +1,16 @@
+Manifest-Version: 1.0
+Bundle-ManifestVersion: 2
+Bundle-Name: SwagEdit Tests
+Bundle-SymbolicName: com.reprezen.swagedit.openapi3.tests
+Bundle-Version: 0.8.0.qualifier
+Fragment-Host: com.reprezen.swagedit.openapi3;bundle-version="0.8.0"
+Bundle-RequiredExecutionEnvironment: JavaSE-1.7
+Require-Bundle: org.junit;bundle-version="4.0.0",
+ com.google.guava,
+ org.eclipse.xtext.xbase.lib,
+ org.eclipse.xtend.lib,
+ org.eclipse.xtend.lib.macro
+Bundle-ClassPath: .,
+ lib/mockito-core-1.10.19.jar,
+ lib/objenesis-2.1.jar
+Bundle-Vendor: ModelSolv, Inc. d.b.a. RepreZen

--- a/com.reprezen.swagedit.openapi3.tests/build.properties
+++ b/com.reprezen.swagedit.openapi3.tests/build.properties
@@ -1,0 +1,6 @@
+bin.includes =  .,\
+               META-INF/,\
+               lib/
+jars.compile.order = .
+source.. = src/,\
+           xtend-gen/

--- a/com.reprezen.swagedit.openapi3.tests/pom.xml
+++ b/com.reprezen.swagedit.openapi3.tests/pom.xml
@@ -1,0 +1,15 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.reprezen</groupId>
+		<artifactId>SwagEdit</artifactId>
+		<version>0.8.0-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+	<artifactId>com.reprezen.swagedit.openapi3.tests</artifactId>
+	<packaging>eclipse-test-plugin</packaging>
+
+</project>

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/CallbacksObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/CallbacksObject.yaml
@@ -1,0 +1,34 @@
+openapi: "3.0.0"
+info:
+  title: Callbacks Object
+  version: "1.0.0"  
+  
+paths: 
+
+  /pets:
+    get:
+      summary: Read
+      description: Provide details for the entire list (for collection resources) or an item (for object resources)
+      responses: {}
+      callbacks:
+        myWebhook:
+         # Operation: KaiZen code assist OK
+          $ref: "#/components/callbacks/myWebho ok"
+
+components: 
+
+  callbacks:
+    myWebhook:
+      '$request.body#/url':
+        post:
+          requestBody:
+            description: Callback payload
+            content: 
+              'application/json':
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: webhook successfully processed and no retries will be performed
+
+ 

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ExamplesObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ExamplesObject.yaml
@@ -1,0 +1,93 @@
+openapi: "3.0.0"
+info:
+  title: Examples Object
+  version: "1.0.0"
+servers:
+  - url: https://api.uber.com/v1
+  
+paths: 
+
+  /pets/{id}:
+# in a parameter
+    parameters:
+      - name: 'zipCode'
+        in: 'query'
+        schema:
+          type: 'string'
+          format: 'zip-code'
+          # KaiZen code-assist shows examples here
+          example: 
+            $ref: 'http://foo.bar#/examples/zip-example'
+        
+    put:
+      description: bla
+      operationId: sd
+      responses: {}
+      requestBody:  
+        description: description
+        content: 
+          "application/json":
+            schema:
+              $ref: model
+            examples:
+              tanya:
+                 summary: summary
+                 externalValue: link
+               
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+    # in a request body:
+      requestBody:
+        content:
+          'application/json':
+            schema:
+              $ref: '#/components/schemas/Address'
+            examples: 
+              foo:
+                summary: A foo example
+                value: {"foo": "bar"}
+              bar:
+                summary: A bar example
+                value: {"bar": "baz"}
+                # KaiZen code assist OK here
+              pizza:
+                $ref: "#/components/examples/confirmation-success"           
+                   
+          'application/xml':
+            examples: 
+              xmlExample:
+                summary: This is an example in XML
+                externalValue: 'http://example.org/examples/address-example.xml'
+          'text/plain':
+            examples:
+              textExample: 
+                summary: This is a text example
+                externalValue: 'http://foo.bar/examples/address-example.txt' 
+    # in a response
+      responses:
+        200:
+          description: your car appointment has been booked
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SuccessResponse'
+              examples:
+                confirmation-success:
+                # KaiZen: code-assist OK here
+                  $ref: '#/components/examples/confirmation-success'
+      
+components:
+
+  schemas:
+    Pet:
+      properties:
+        name:
+          type: string
+          example:
+        # KaiZen: code-assist OK here
+             $ref: http://foo.bar#/examples/name-example
+            
+  examples: 
+    confirmation-success:
+      summary: this is confirmation success example

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/HeadersObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/HeadersObject.yaml
@@ -1,0 +1,50 @@
+openapi: "3.0.0"
+info:
+  title: Headers Object
+  version: "1.0.0"
+servers:
+  - url: https://api.uber.com/v1
+  
+paths: 
+
+  /pets:
+    get:
+      summary: Read
+      description: Provide details for the entire list (for collection resources) or an item (for object resources)
+      responses:
+        '200':
+          description: A simple string response
+          content:
+            text/plain:
+              schema:
+                type: string
+              example: 'whoa!'
+          headers:
+            X-Rate-Limit-Limit:
+              description: The number of allowed requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Remaining:
+              description: The number of remaining requests in the current period
+              schema:
+                type: integer
+            X-Rate-Limit-Reset:
+            # In Responses: KaiZen code assist OK
+              $ref: "#/components/headers/X-Rate-Limit-Reset"   
+
+components: 
+
+  headers:
+    X-Rate-Limit-Reset:
+      description: The number of seconds left in the current period
+      schema:
+        type: integer         
+    
+  links:
+    UserRepositories:
+      operationId: getRepositoriesByOwner
+      headers:
+        X-Rate-Limit-Reset:
+          # In Links: KaiZen code assist OK
+          $ref: "#/components/headers/X-Rate-Limit-Reset"
+ 

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/LinksObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/LinksObject.yaml
@@ -1,0 +1,218 @@
+openapi: "3.0.0"
+info:
+  title: Links Object
+  version: "1.0.0"  
+  
+paths: 
+
+  /2.0/users/{username}: 
+    get: 
+      operationId: getUserByName
+      parameters: 
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      responses: 
+        '200':
+          description: The User
+          content:
+            application/json:
+              schema: 
+                $ref: '#/components/schemas/user'
+          links:
+            userRepositories:
+             ## KaiZen code-assist OK
+              $ref: '#/components/links/UserRepositories'
+              
+  /2.0/repositories/{username}:
+    get:
+      operationId: getRepositoriesByOwner
+      parameters:
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: repositories owned by the supplied user
+          content: 
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/repository'
+          links:
+            userRepository:
+              ## KaiZen code-assist OK
+              $ref: '#/components/links/UserRepository'
+              
+  /2.0/repositories/{username}/{slug}: 
+    get: 
+      operationId: getRepository
+      parameters: 
+        - name: username
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: slug
+          in: path
+          required: true
+          schema:
+            type: string
+      responses: 
+        '200':
+          description: The repository
+          content:
+              application/json: 
+                schema: 
+                  $ref: '#/components/schemas/repository'
+          links:
+            repositoryPullRequests:
+               # KaiZen code-assist OK
+              $ref: '#/components/links/RepositoryPullRequests'
+              
+  /2.0/repositories/{username}/{slug}/pullrequests: 
+    get: 
+      operationId: getPullRequestsByRepository
+      parameters: 
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: state
+        in: query
+        schema:
+          type: string
+          enum: 
+            - open
+            - merged
+            - declined
+      responses: 
+        '200':
+          description: an array of pull request objects
+          content:
+            application/json: 
+              schema: 
+                type: array
+                items: 
+                  $ref: '#/components/schemas/pullrequest'
+                  
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}: 
+    get: 
+      operationId: getPullRequestsById
+      parameters: 
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses: 
+        '200':
+          description: a pull request object
+          content:
+            application/json: 
+              schema: 
+                $ref: '#/components/schemas/pullrequest'
+          links:
+            pullRequstMerge:
+               ## KaiZen code-assist OK
+              $ref: '#/components/links/PullRequestMerge'
+            
+  /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge: 
+    post: 
+      operationId: mergePullRequest
+      parameters: 
+      - name: username
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: slug
+        in: path
+        required: true
+        schema:
+          type: string
+      - name: pid
+        in: path
+        required: true
+        schema:
+          type: string
+      responses: 
+        '204':
+          description: the PR was successfully merged
+
+components:
+
+  links:
+    UserRepositories:
+      # returns array of '#/components/schemas/repository'
+      operationId: getRepositoriesByOwner
+      parameters:
+        username: $response.body#/username
+    UserRepository:
+      # returns '#/components/schemas/repository'
+      operationId: getRepository
+      parameters:
+        username: $response.body#/owner/username
+        slug: $response.body#/slug
+    RepositoryPullRequests:
+      # returns '#/components/schemas/pullrequest'
+      operationId: getPullRequestsByRepository
+      parameters: 
+          username: $response.body#/owner/username
+          slug: $response.body#/slug
+    PullRequestMerge:
+      # executes /2.0/repositories/{username}/{slug}/pullrequests/{pid}/merge
+      operationId: mergePullRequest
+      parameters:
+        username: $response.body#/author/username
+        slug: $response.body#/repository/slug
+        pid: $response.body#/id
+  schemas: 
+    user: 
+      type: object
+      properties: 
+        username: 
+          type: string
+        uuid: 
+          type: string
+    repository: 
+      type: object
+      properties: 
+        slug: 
+          type: string
+        owner: 
+          $ref: '#/components/schemas/user'
+    pullrequest: 
+      type: object
+      properties: 
+        id: 
+          type: integer
+        title: 
+          type: string
+        repository: 
+          $ref: '#/components/schemas/repository'
+        author: 
+          $ref: '#/components/schemas/user'
+
+ 

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/Parameter.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/Parameter.yaml
@@ -1,0 +1,68 @@
+openapi: "3.0.0"
+info:
+  title: Headers Object
+  version: "1.0.0"
+servers:
+  - url: https://api.uber.com/v1
+  
+paths: 
+
+  /pets:
+    parameters:
+     - $ref: "#/components/parameters/username"
+    get:
+      parameters:
+        - $ref: "#/components/parameters/id"
+      summary: Read
+      description: Provide details for the entire list (for collection resources) or an item (for object resources)
+      responses:
+        '200':
+          description: A simple string response
+          
+components: 
+
+  parameters:
+    # header parameter
+    token:
+      name: token
+      in: header
+      description: token to be passed as a header
+      required: true
+      schema:
+        type: array
+        items:
+          type: integer
+          format: int64
+      style: commaDelimited  
+
+# path parameter      
+    username:
+      name: username
+      in: path
+      description: username to fetch
+      required: true
+      schema:
+        type: string 
+        
+   # query parameter
+    id:
+      name: id
+      in: query
+      description: ID of the object to fetch
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+      style: form
+      explode: true        
+      
+      # freeform query parameter
+    freeform:
+      in: query
+      name: freeForm
+      schema:
+        type: object
+        additionalProperties:
+          type: integer
+      style: form

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/PathItem.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/PathItem.yaml
@@ -1,0 +1,18 @@
+openapi: "3.0.0"
+info:
+  title: Callbacks Object
+  version: "1.0.0"  
+  
+paths: 
+
+  /pets:
+    $ref: "HeadersObject.yaml#/paths/~1pets"
+      
+components: 
+
+  callbacks:
+    myWebhook:
+      '$request.body#/url':
+        $ref: "HeadersObject.yaml#/paths/~1pets"
+
+ 

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/RequestBody.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/RequestBody.yaml
@@ -1,0 +1,140 @@
+openapi: "3.0.0"
+info:
+  title: Headers Object
+  version: "1.0.0"
+servers:
+  - url: https://api.uber.com/v1
+  
+paths: 
+
+  /pets:
+    post:
+      summary: Create
+      description: Create a new item
+      requestBody:
+        $ref: "#/components/requestBodies/forPost"
+      responses:
+        '200':
+          description: OK
+          
+components: 
+
+  callbacks:
+    myWebhook:
+      '$request.body#/url':
+        post:
+          requestBody:
+            $ref: "#/components/requestBodies/www-form-urlencoded"
+          responses: {}
+              
+  requestBodies:
+  
+    forPost:
+      content:
+        application/octet-stream:
+          # any media type is accepted, functionally equivalent to `*/*`
+          schema:
+            # a binary file of any type
+            type: string
+            format: binary
+        'image/png, image/jpeg':
+          # a binary file of type png or jpeg
+          schema:
+            type: string
+            format: binary        
+        
+    www-form-urlencoded:
+      content:
+        x-www-form-urlencoded:
+          schema:
+            type: object
+            properties:
+              id:
+                type: string
+                format: uuid
+              address:
+                # complex types are stringified to support RFC 1866
+                type: object
+                properties: {}
+
+    multipart:
+       content: 
+         multipart/form-data:
+           schema:
+             type: object
+             properties:
+                id:
+                  type: string
+                  format: uuid
+                address:
+                  # default Content-Type for objects is `application/json`
+                  type: object
+                  properties: {}
+                profileImage:
+                  # default Content-Type for string/binary is `application/octet-stream`
+                  type: string
+                  format: binary
+                children:
+                  # default Content-Type for arrays is based on the `inner` type (text/plain here)
+                  type: array
+                  items:
+                    type: string
+                addresses:
+                  # default Content-Type for arrays is based on the `inner` type (object shown, so `application/json` in this example)
+                  type: array
+                  items:
+                    type: '#/components/schemas/Address'    
+                    
+    withEncoding:
+      content:
+        multipart/mixed:
+          schema:
+            type: object
+            properties:
+              id:
+                # default is text/plain
+                type: string
+                format: uuid
+              address:
+                # default is application/json
+                type: object
+                properties: {}
+              historyMetadata:
+                # need to declare XML format!
+                description: metadata in XML format
+                type: object
+                properties: {}
+              profileImage:
+                # default is application/octet-stream, need to declare an image type only!
+                type: string
+                format: binary
+          encoding:
+            historyMetadata:
+              # require XML Content-Type in utf-8 encoding
+              contentType: application/xml; charset=utf-8
+            profileImage:
+              # only accept png/jpeg
+              contentType: image/png, image/jpeg
+              headers:
+                X-Rate-Limit-Limit:
+                description: The number of allowed requests in the current period
+                type: integer                        
+                
+    # FIXME: fix examples in requestBody
+    withExamples:
+  # in a request body, note the plural `examples` as the Content-Type is set to `*`:
+      content:
+        'application/json':
+          schema:
+            $ref: '#/components/schemas/Address'
+#          examples: 
+#            - {"foo": "bar"}
+#            - {"bar": "baz"}
+#        'application/xml':
+#          examples: 
+#            - $ref: 'http://foo.bar#/examples/address-example.xml' 
+#        'text/plain':
+#          examples: 
+#            - $ref: 'http://foo.bar#/examples/address-example.txt'                 
+                    
+                    

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/SecuitySchemesObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/SecuitySchemesObject.yaml
@@ -1,0 +1,34 @@
+openapi: "3.0.0"
+info:
+  title: Security Schemes Object
+  version: "1.0.0"  
+  
+paths: 
+
+  /pets:
+    get:
+      summary: Read
+      description: Provide details for the entire list (for collection resources) or an item (for object resources)
+      responses: {}
+      security:
+        - petstore_auth:
+          - write:pets
+          - read:pets
+
+components: 
+
+  securitySchemes:
+    api_key:
+      type: apiKey 
+      name: api_key
+      in: header
+    petstore_auth:
+      type: oauth2
+      flows: 
+        implicit:
+          authorizationUrl: http://example.org/api/oauth/dialog
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+
+ 

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
@@ -63,4 +63,21 @@ class JsonReferenceContextTest {
 			"/components/schemas/Pet/properties/name/example/$ref".matches(
 				OpenApi3ReferenceProposalProvider.SCHEMA_EXAMPLE_REGEX))
 	}
+	
+
+	@Test
+	def void link_in_response() {
+		assertTrue(
+			"/paths/~12.0~1users~1{username}/get/responses/200/links/userRepositories/$ref".matches(
+				OpenApi3ReferenceProposalProvider.LINK_REGEX))
+		assertTrue(
+			"/paths/~12.0~1repositories~1{username}/get/responses/200/links/userRepository/$ref".matches(
+				OpenApi3ReferenceProposalProvider.LINK_REGEX))
+		assertTrue(
+			"/paths/~12.0~1repositories~1{username}~1{slug}/get/responses/200/links/repositoryPullRequests/$ref".matches(
+				OpenApi3ReferenceProposalProvider.LINK_REGEX))
+		assertTrue(
+			"/paths/~12.0~1repositories~1{username}~1{slug}~1pullrequests~1{pid}/get/responses/200/links/pullRequst/$ref".matches(
+				OpenApi3ReferenceProposalProvider.LINK_REGEX))
+	}	
 }

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.openapi3.assist
+
+import org.junit.Test
+
+import static org.junit.Assert.*
+
+class JsonReferenceContextTest {
+
+	@Test
+	def void headers_in_response() {
+		assertTrue(
+			"/paths/~1pets/get/responses/200/headers/X-Rate-Limit-Reset/$ref".matches(
+				OpenApi3ReferenceProposalProvider.HEADER_REGEX))
+	}
+
+	@Test
+	def void headers_in_link() {
+		assertTrue(
+			"/components/links/UserRepositories/headers/X-Rate-Limit-Reset/$ref".matches(
+				OpenApi3ReferenceProposalProvider.HEADER_REGEX))
+	}
+
+	@Test
+	def void callbacks_in_operation() {
+		assertTrue(
+			"/paths/~1pets/get/callbacks/myWebhook/$ref".matches(OpenApi3ReferenceProposalProvider.CALLBACK_REGEX))
+	}
+
+	@Test
+	def void example_in_parameter_schema() {
+		assertTrue(
+			"/paths/~1pets~1{id}/parameters/0/schema/example/$ref".matches(
+				OpenApi3ReferenceProposalProvider.SCHEMA_EXAMPLE_REGEX))
+	}
+
+	@Test
+	def void examples_in_requestBody() {
+		assertTrue(
+			"/paths/~1pets~1{id}/post/requestBody/content/application~1json/examples/pizza/$ref".matches(
+				OpenApi3ReferenceProposalProvider.EXAMPLE_REGEX))
+	}
+
+	@Test
+	def void examples_in_response() {
+		assertTrue(
+			"/paths/~1pets~1{id}/post/responses/200/content/application~1json/examples/confirmation-success/$ref".
+				matches(OpenApi3ReferenceProposalProvider.EXAMPLE_REGEX))
+	}
+
+	@Test
+	def void example_in_property() {
+		assertTrue(
+			"/components/schemas/Pet/properties/name/example/$ref".matches(
+				OpenApi3ReferenceProposalProvider.SCHEMA_EXAMPLE_REGEX))
+	}
+}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
@@ -27,6 +27,16 @@ class JsonReferenceContextTest {
 	}
 
 	@Test
+	def void requestBody_in_callback() {
+		assertTrue("/components/callbacks/myWebhook/$request.body#~1url/post/requestBody/$ref".matches(OpenApi3ReferenceProposalProvider.PARAMETER_REGEX))
+	}
+
+	@Test
+	def void requestBody_in_operation() {
+		assertTrue("/paths/~1pets/post/requestBody/$ref".matches(OpenApi3ReferenceProposalProvider.PARAMETER_REGEX))
+	}
+
+	@Test
 	def void path_item_in_paths_object() {
 		assertTrue("/paths/~1pets/$ref".matches(OpenApi3ReferenceProposalProvider.PATH_ITEM_REGEX))
 	}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
@@ -17,6 +17,20 @@ import static org.junit.Assert.*
 class JsonReferenceContextTest {
 
 	@Test
+	def void path_item_in_paths_object() {
+		assertTrue(
+			"/paths/~1pets/$ref".matches(
+				OpenApi3ReferenceProposalProvider.PATH_ITEM_REGEX))
+	}
+
+	@Test
+	def void path_item_in_callback() {
+		assertTrue(
+			"/components/callbacks/myWebhook/$request.body#~1url/$ref".matches(
+				OpenApi3ReferenceProposalProvider.PATH_ITEM_REGEX))
+	}
+	
+	@Test
 	def void headers_in_response() {
 		assertTrue(
 			"/paths/~1pets/get/responses/200/headers/X-Rate-Limit-Reset/$ref".matches(

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceContextTest.xtend
@@ -17,10 +17,18 @@ import static org.junit.Assert.*
 class JsonReferenceContextTest {
 
 	@Test
+	def void parameter_in_path_item() {
+		assertTrue("/paths/~1pets/parameters/0/$ref".matches(OpenApi3ReferenceProposalProvider.PARAMETER_REGEX))
+	}
+
+	@Test
+	def void parameter_in_operation() {
+		assertTrue("/paths/~1pets/get/parameters/0/$ref".matches(OpenApi3ReferenceProposalProvider.PARAMETER_REGEX))
+	}
+
+	@Test
 	def void path_item_in_paths_object() {
-		assertTrue(
-			"/paths/~1pets/$ref".matches(
-				OpenApi3ReferenceProposalProvider.PATH_ITEM_REGEX))
+		assertTrue("/paths/~1pets/$ref".matches(OpenApi3ReferenceProposalProvider.PATH_ITEM_REGEX))
 	}
 
 	@Test

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -18,15 +18,17 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
 	public OpenApi3ReferenceProposalProvider() {
 		super(OPEN_API3_CONTEXT_TYPES);
 	}
-
+    
+	protected static final String COMPONENT_NAME_REGEX = "[\\w\\.\\-]+";
+	
 	protected static final String SCHEMA_DEFINITION_REGEX = "^/components/schemas/(\\w+/)+\\$ref|.*schema/(\\w+/)?\\$ref";
 	protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref";
     protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
     protected static final String RESPONSE_REGEX = ".*/responses/\\d+/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
     protected static final String LINK_REGEX = ".*/links/\\w+/\\$ref";
-    protected static final String EXAMPLE_REGEX = ".*/examples/[\\w\\.\\-]+/\\$ref";
-    protected static final String HEADER_REGEX = ".*/headers/\\w+/\\$ref";
+    protected static final String EXAMPLE_REGEX = ".*/examples/"+COMPONENT_NAME_REGEX +"/\\$ref";
+    protected static final String HEADER_REGEX = ".*/headers/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String CALLBACK_REGEX = ".*/callbacks/\\w+/\\$ref";
     protected static final String SECURITY_SCHEME_REGEX = ".*/security/\\w+/\\$ref";
 

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -30,8 +30,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     protected static final String EXAMPLE_REGEX = ".*/examples/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String HEADER_REGEX = ".*/headers/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String CALLBACK_REGEX = ".*/callbacks/"+COMPONENT_NAME_REGEX +"/\\$ref";
-    protected static final String SECURITY_SCHEME_REGEX = ".*/security/\\w+/\\$ref";
-
+   
 	public static final ContextType SCHEMA_DEFINITION = new ContextType("components/schemas", "schemas",
 			SCHEMA_DEFINITION_REGEX);
 	public static final ContextType PATH_ITEM = new ContextType("paths", "path items", PATH_ITEM_REGEX);
@@ -45,8 +44,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     public static final ContextType EXAMPLE = new ContextType("components/examples", "example", EXAMPLE_REGEX);
     public static final ContextType HEADER = new ContextType("components/headers", "header", HEADER_REGEX);
     public static final ContextType CALLBACK = new ContextType("components/callbacks", "callback", CALLBACK_REGEX);
-    public static final ContextType SECURITY_SCHEME = new ContextType("components/securitySchemes", "security scheme", SECURITY_SCHEME_REGEX);
-
+   
     public static final ContextTypeCollection OPEN_API3_CONTEXT_TYPES = ContextType
             .newContentTypeCollection(Lists.newArrayList( //
                     SCHEMA_DEFINITION, //
@@ -57,8 +55,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
                     PATH_LINK, //
                     EXAMPLE, //
                     HEADER, //
-                    CALLBACK, //
-                    SECURITY_SCHEME //
+                    CALLBACK//
                     ));
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -46,13 +46,13 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
             REQUEST_BODY_REGEX);
     public static final ContextType PATH_LINK = new ContextType("components/links", "link", LINK_REGEX);
     public static final ContextType EXAMPLE = new ContextType("components/examples", "examples", EXAMPLE_REGEX);
-    public static final ContextType SCHEMA_EXAMPLE = new ContextType("components/examples", "example", SCHEMA_EXAMPLE_REGEX);
+    //public static final ContextType SCHEMA_EXAMPLE = new ContextType("its/not/example/component", "example", SCHEMA_EXAMPLE_REGEX);
     public static final ContextType HEADER = new ContextType("components/headers", "header", HEADER_REGEX);
     public static final ContextType CALLBACK = new ContextType("components/callbacks", "callback", CALLBACK_REGEX);
    
     public static final ContextTypeCollection OPEN_API3_CONTEXT_TYPES = ContextType
             .newContentTypeCollection(Lists.newArrayList( //
-                    SCHEMA_EXAMPLE, // should go before schema definition
+                  //  SCHEMA_EXAMPLE, // should go before schema definition
                     SCHEMA_DEFINITION, //
                     PATH_ITEM, //
                     PATH_PARAMETER, //

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -21,13 +21,17 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     
 	protected static final String COMPONENT_NAME_REGEX = "[\\w\\.\\-]+";
 	
-	protected static final String SCHEMA_DEFINITION_REGEX = "^/components/schemas/(\\w+/)+\\$ref|.*schema/(\\w+/)?\\$ref";
+    protected static final String SCHEMA_COMPONENT_REGEX = "^/components/schemas/(\\w+/)+";
+    protected static final String INLINE_SCHEMA_REGEX = ".*schema/(\\w+/)?";
+	protected static final String SCHEMA_DEFINITION_REGEX = SCHEMA_COMPONENT_REGEX + "\\$ref" + "|" + INLINE_SCHEMA_REGEX + "\\$ref";
 	protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref";
     protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
     protected static final String RESPONSE_REGEX = ".*/responses/\\d+/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
     protected static final String LINK_REGEX = ".*/links/\\w+/\\$ref";
     protected static final String EXAMPLE_REGEX = ".*/examples/"+COMPONENT_NAME_REGEX +"/\\$ref";
+    protected static final String SCHEMA_EXAMPLE_REGEX = SCHEMA_COMPONENT_REGEX + ".*/example/\\$ref" + "|"
+            + INLINE_SCHEMA_REGEX + ".*/example/\\$ref";
     protected static final String HEADER_REGEX = ".*/headers/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String CALLBACK_REGEX = ".*/callbacks/"+COMPONENT_NAME_REGEX +"/\\$ref";
    
@@ -41,12 +45,14 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     public static final ContextType PATH_REQUEST_BODY = new ContextType("components/requestBodies", "requestBody",
             REQUEST_BODY_REGEX);
     public static final ContextType PATH_LINK = new ContextType("components/links", "link", LINK_REGEX);
-    public static final ContextType EXAMPLE = new ContextType("components/examples", "example", EXAMPLE_REGEX);
+    public static final ContextType EXAMPLE = new ContextType("components/examples", "examples", EXAMPLE_REGEX);
+    public static final ContextType SCHEMA_EXAMPLE = new ContextType("components/examples", "example", SCHEMA_EXAMPLE_REGEX);
     public static final ContextType HEADER = new ContextType("components/headers", "header", HEADER_REGEX);
     public static final ContextType CALLBACK = new ContextType("components/callbacks", "callback", CALLBACK_REGEX);
    
     public static final ContextTypeCollection OPEN_API3_CONTEXT_TYPES = ContextType
             .newContentTypeCollection(Lists.newArrayList( //
+                    SCHEMA_EXAMPLE, // should go before schema definition
                     SCHEMA_DEFINITION, //
                     PATH_ITEM, //
                     PATH_PARAMETER, //

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -29,7 +29,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     protected static final String LINK_REGEX = ".*/links/\\w+/\\$ref";
     protected static final String EXAMPLE_REGEX = ".*/examples/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String HEADER_REGEX = ".*/headers/"+COMPONENT_NAME_REGEX +"/\\$ref";
-    protected static final String CALLBACK_REGEX = ".*/callbacks/\\w+/\\$ref";
+    protected static final String CALLBACK_REGEX = ".*/callbacks/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String SECURITY_SCHEME_REGEX = ".*/security/\\w+/\\$ref";
 
 	public static final ContextType SCHEMA_DEFINITION = new ContextType("components/schemas", "schemas",

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -21,12 +21,29 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
 
 	protected static final String SCHEMA_DEFINITION_REGEX = "^/components/schemas/(\\w+/)+\\$ref|.*schema/(\\w+/)?\\$ref";
 	protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref";
+    protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
+    protected static final String RESPONSE_REGEX = ".*/responses/\\d+/\\$ref";
+    protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
+    protected static final String LINK_REGEX = ".*/links/\\w+/\\$ref";
 
 	public static final ContextType SCHEMA_DEFINITION = new ContextType("components/schemas", "schemas",
 			SCHEMA_DEFINITION_REGEX);
 	public static final ContextType PATH_ITEM = new ContextType("paths", "path items", PATH_ITEM_REGEX);
+    public static final ContextType PATH_PARAMETER = new ContextType("components/parameters", "parameters",
+            PARAMETER_REGEX);
+    public static final ContextType PATH_RESPONSE = new ContextType("components/responses", "responses",
+            RESPONSE_REGEX);
+    public static final ContextType PATH_REQUEST_BODY = new ContextType("components/requestBodies", "requestBody",
+            REQUEST_BODY_REGEX);
+    public static final ContextType PATH_LINK = new ContextType("components/links", "link", LINK_REGEX);
 
-	public static final ContextTypeCollection OPEN_API3_CONTEXT_TYPES = ContextType
-			.newContentTypeCollection(Lists.newArrayList(SCHEMA_DEFINITION, PATH_ITEM));
+    public static final ContextTypeCollection OPEN_API3_CONTEXT_TYPES = ContextType
+            .newContentTypeCollection(Lists.newArrayList( //
+                    SCHEMA_DEFINITION, //
+                    PATH_ITEM, //
+                    PATH_PARAMETER, //
+                    PATH_RESPONSE, //
+                    PATH_REQUEST_BODY, //
+                    PATH_LINK));
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -25,6 +25,10 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     protected static final String RESPONSE_REGEX = ".*/responses/\\d+/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
     protected static final String LINK_REGEX = ".*/links/\\w+/\\$ref";
+    protected static final String EXAMPLE_REGEX = ".*/examples/[\\w\\.\\-]+/\\$ref";
+    protected static final String HEADER_REGEX = ".*/headers/\\w+/\\$ref";
+    protected static final String CALLBACK_REGEX = ".*/callbacks/\\w+/\\$ref";
+    protected static final String SECURITY_SCHEME_REGEX = ".*/security/\\w+/\\$ref";
 
 	public static final ContextType SCHEMA_DEFINITION = new ContextType("components/schemas", "schemas",
 			SCHEMA_DEFINITION_REGEX);
@@ -36,6 +40,10 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     public static final ContextType PATH_REQUEST_BODY = new ContextType("components/requestBodies", "requestBody",
             REQUEST_BODY_REGEX);
     public static final ContextType PATH_LINK = new ContextType("components/links", "link", LINK_REGEX);
+    public static final ContextType EXAMPLE = new ContextType("components/examples", "example", EXAMPLE_REGEX);
+    public static final ContextType HEADER = new ContextType("components/headers", "header", HEADER_REGEX);
+    public static final ContextType CALLBACK = new ContextType("components/callbacks", "callback", CALLBACK_REGEX);
+    public static final ContextType SECURITY_SCHEME = new ContextType("components/securitySchemes", "security scheme", SECURITY_SCHEME_REGEX);
 
     public static final ContextTypeCollection OPEN_API3_CONTEXT_TYPES = ContextType
             .newContentTypeCollection(Lists.newArrayList( //
@@ -44,6 +52,11 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
                     PATH_PARAMETER, //
                     PATH_RESPONSE, //
                     PATH_REQUEST_BODY, //
-                    PATH_LINK));
+                    PATH_LINK, //
+                    EXAMPLE, //
+                    HEADER, //
+                    CALLBACK, //
+                    SECURITY_SCHEME //
+                    ));
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -22,7 +22,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
 	protected static final String COMPONENT_NAME_REGEX = "[\\w\\.\\-]+";
 	
     protected static final String SCHEMA_COMPONENT_REGEX = "^/components/schemas/(\\w+/)+";
-    protected static final String INLINE_SCHEMA_REGEX = ".*schema/(\\w+/)?";
+    protected static final String INLINE_SCHEMA_REGEX = ".*schema/(\\w+/)*";
 	protected static final String SCHEMA_DEFINITION_REGEX = SCHEMA_COMPONENT_REGEX + "\\$ref" + "|" + INLINE_SCHEMA_REGEX + "\\$ref";
 	protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref";
     protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
@@ -30,8 +30,8 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
     protected static final String LINK_REGEX = ".*/links/\\w+/\\$ref";
     protected static final String EXAMPLE_REGEX = ".*/examples/"+COMPONENT_NAME_REGEX +"/\\$ref";
-    protected static final String SCHEMA_EXAMPLE_REGEX = SCHEMA_COMPONENT_REGEX + ".*/example/\\$ref" + "|"
-            + INLINE_SCHEMA_REGEX + ".*/example/\\$ref";
+    protected static final String SCHEMA_EXAMPLE_REGEX = SCHEMA_COMPONENT_REGEX + "example/\\$ref" + "|"
+            + INLINE_SCHEMA_REGEX + "example/\\$ref";
     protected static final String HEADER_REGEX = ".*/headers/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String CALLBACK_REGEX = ".*/callbacks/"+COMPONENT_NAME_REGEX +"/\\$ref";
    

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -24,7 +24,9 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     protected static final String SCHEMA_COMPONENT_REGEX = "^/components/schemas/(\\w+/)+";
     protected static final String INLINE_SCHEMA_REGEX = ".*schema/(\\w+/)*";
 	protected static final String SCHEMA_DEFINITION_REGEX = SCHEMA_COMPONENT_REGEX + "\\$ref" + "|" + INLINE_SCHEMA_REGEX + "\\$ref";
-	protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref";
+    protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref"// in paths object
+            // e.g. "/components/callbacks/myWebhook/$request.body#~1url/$ref"
+            + "|/components/callbacks/" + COMPONENT_NAME_REGEX + "/[^/]+/\\$ref"; // in callbacks
     protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
     protected static final String RESPONSE_REGEX = ".*/responses/\\d+/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -28,7 +28,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
     protected static final String RESPONSE_REGEX = ".*/responses/\\d+/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
-    protected static final String LINK_REGEX = ".*/links/\\w+/\\$ref";
+    protected static final String LINK_REGEX = ".*/links/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String EXAMPLE_REGEX = ".*/examples/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String SCHEMA_EXAMPLE_REGEX = SCHEMA_COMPONENT_REGEX + "example/\\$ref" + "|"
             + INLINE_SCHEMA_REGEX + "example/\\$ref";

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
 		<module>com.reprezen.swagedit.openapi3</module>
 		<module>com.reprezen.swagedit.feature</module>
 		<module>com.reprezen.swagedit.tests</module>
+        <module>com.reprezen.swagedit.openapi3.tests</module>
 		<module>com.reprezen.swagedit.repository</module>
 		<module>com.reprezen.swagedit.target</module>
 		<module>com.reprezen.swagedit.target.kepler</module>


### PR DESCRIPTION
Initial implementation of code assist for references.
It also provides tests for code assist for references to:
* parameter,
* path item,
* callback,
* header,
* example
* link
