### PR TITLE
ZEN-3460: Make the editor class visible to other plugins via `Export-Package`

### DIFF
--- a/com.reprezen.swagedit.openapi3/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit.openapi3/META-INF/MANIFEST.MF
@@ -20,3 +20,4 @@ Bundle-ActivationPolicy: lazy
 Import-Package: com.fasterxml.jackson.core,
  com.fasterxml.jackson.databind,
  io.swagger.util
+Export-Package: com.reprezen.swagedit.openapi3.editor


### PR DESCRIPTION
I need this change for ZEN-3460 "OpenAPI v3 Live Views: SwagEditorSource for v3". 
It does not change existing functionality, only makes `OpenApi3Editor` and other classes from its package visible to other plugins.