### PR TITLE
#268 - Content assist typeahead should be case-insensitive

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/Proposal.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/Proposal.java
@@ -62,7 +62,7 @@ public class Proposal {
         StyledCompletionProposal proposal = null;
         if (Strings.emptyToNull(prefix) == null) {
             proposal = new StyledCompletionProposal(replacementString, styledString, null, description, offset);
-        } else if (replacementString.contains(prefix) || replacementString.startsWith(prefix)) {
+        } else if (replacementString.toLowerCase().contains(prefix.toLowerCase())) {
             proposal = new StyledCompletionProposal(replacementString, styledString, prefix, description, offset);
         }
 

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/StyledCompletionProposal.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/StyledCompletionProposal.java
@@ -32,13 +32,14 @@ public class StyledCompletionProposal
     private final String replacementString;
     private final StyledString label;
     private final String description;
+    /** Lower-cased prefix - content assist typeahead should be case-insensitive */
     private final String prefix;
 
     public StyledCompletionProposal(String replacement, StyledString label, String prefix, String description,
             int offset) {
         this.label = label;
         this.replacementString = replacement;
-        this.prefix = prefix;
+        this.prefix = prefix != null ? prefix.toLowerCase() : null;
         this.replacementOffset = offset;
         this.description = description;
     }
@@ -55,9 +56,9 @@ public class StyledCompletionProposal
         String text = replacementString;
 
         if (Strings.emptyToNull(prefix) != null) {
-            if (replacementString.startsWith(prefix)) {
+            if (replacementString.toLowerCase().startsWith(prefix)) {
                 text = replacementString.substring(prefix.length());
-            } else if (replacementString.contains(prefix)) {
+            } else if (replacementString.toLowerCase().contains(prefix)) {
                 offset = replacementOffset - prefix.length();
                 length = prefix.length();
             }
@@ -75,9 +76,9 @@ public class StyledCompletionProposal
         int offset = replacementOffset;
 
         if (Strings.emptyToNull(prefix) != null) {
-            if (replacementString.startsWith(prefix)) {
+            if (replacementString.toLowerCase().startsWith(prefix)) {
                 offset = replacementOffset - prefix.length();
-            } else if (replacementString.contains(prefix)) {
+            } else if (replacementString.toLowerCase().contains(prefix)) {
                 offset = replacementOffset - prefix.length();
             }
         }


### PR DESCRIPTION
Typeahead on OpenAPI v3 models:
![ref_assist1](https://cloud.githubusercontent.com/assets/644582/26383303/00a2be16-4000-11e7-8605-3822f461c6c4.gif)
Similar on Swagger v2:
![ref_assist2](https://cloud.githubusercontent.com/assets/644582/26383302/00a1784e-4000-11e7-9759-a26430cbd443.gif)
