### PR TITLE
[#307] OpenAPI v3: Code assist for Link#operationId

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonContentAssistProcessor.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonContentAssistProcessor.java
@@ -52,7 +52,6 @@ import com.reprezen.swagedit.core.Activator;
 import com.reprezen.swagedit.core.Activator.Icons;
 import com.reprezen.swagedit.core.assist.JsonReferenceProposalProvider.ContextType;
 import com.reprezen.swagedit.core.editor.JsonDocument;
-import com.reprezen.swagedit.core.json.references.JsonReference;
 import com.reprezen.swagedit.core.json.references.Messages;
 import com.reprezen.swagedit.core.model.Model;
 import com.reprezen.swagedit.core.templates.SwaggerTemplateContext;
@@ -134,8 +133,7 @@ public abstract class JsonContentAssistProcessor extends TemplateCompletionProce
 
         Model model = document.getModel(documentOffset - prefix.length());
         currentPath = model.getPath(line, column);
-
-        isRefCompletion = currentPath != null && currentPath.toString().endsWith(JsonReference.PROPERTY);
+        isRefCompletion = referenceProposalProvider.canProvideProposal(currentPath);
 
         Collection<Proposal> p;
         if (isRefCompletion) {

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
@@ -35,20 +35,20 @@ import com.reprezen.swagedit.core.validation.ValidationUtil;
 public class JsonReferenceProposalProvider {
 
     private final JsonDocumentManager manager = JsonDocumentManager.getInstance();
-	private final ContextTypeCollection contextTypes;
-	private final String fileContentType;
-    
+    private final ContextTypeCollection contextTypes;
+    private final String fileContentType;
+
     public JsonReferenceProposalProvider(ContextTypeCollection contextTypes, String fileContentType) {
-		this.contextTypes = contextTypes;
-		this.fileContentType = fileContentType;
-	}
+        this.contextTypes = contextTypes;
+        this.fileContentType = fileContentType;
+    }
 
     protected IFile getActiveFile() {
         return DocumentUtils.getActiveEditorInput().getFile();
     }
-    
+
     protected ContextTypeCollection getContextTypes() {
-    	return contextTypes;
+        return contextTypes;
     }
 
     public boolean canProvideProposal(JsonPointer pointer) {
@@ -101,13 +101,13 @@ public class JsonReferenceProposalProvider {
 
         private final String value;
         private final String label;
-		private final String regex;
+        private final String regex;
         private final boolean isLocalOnly;
 
         public ContextType(String value, String label, String regex) {
             this.value = value;
             this.label = label;
-			this.regex = regex;
+            this.regex = regex;
             this.isLocalOnly = false;
         }
 
@@ -163,12 +163,12 @@ public class JsonReferenceProposalProvider {
         }
 
         public static ContextTypeCollection newContentTypeCollection(Iterable<ContextType> contextTypes) {
-        	return new ContextTypeCollection(contextTypes);
+            return new ContextTypeCollection(contextTypes);
         }
-        
-		public static ContextTypeCollection emptyContentTypeCollection() {
-			return new ContextTypeCollection(Collections.<ContextType>emptyList());
-		}
+
+        public static ContextTypeCollection emptyContentTypeCollection() {
+            return new ContextTypeCollection(Collections.<ContextType> emptyList());
+        }
     }
 
     public static class ContextTypeValue extends ContextType {
@@ -204,24 +204,24 @@ public class JsonReferenceProposalProvider {
     }
 
     public static class ContextTypeCollection {
-    	
-    	private final Iterable<ContextType> contextTypes;
 
-		protected ContextTypeCollection(Iterable<ContextType> contextTypes) {
-			this.contextTypes = contextTypes;
-    	}
-		
-		public ContextType get(String path) {
-			if (Strings.emptyToNull(path) == null) {
-				return ContextType.UNKNOWN;
-			}
-			for (ContextType next : contextTypes) {
-				if (path.matches(next.regex)) {
-					return next;
-				}
-			}
-			return ContextType.UNKNOWN;
-		}
+        private final Iterable<ContextType> contextTypes;
+
+        protected ContextTypeCollection(Iterable<ContextType> contextTypes) {
+            this.contextTypes = contextTypes;
+        }
+
+        public ContextType get(String path) {
+            if (Strings.emptyToNull(path) == null) {
+                return ContextType.UNKNOWN;
+            }
+            for (ContextType next : contextTypes) {
+                if (path.matches(next.regex)) {
+                    return next;
+                }
+            }
+            return ContextType.UNKNOWN;
+        }
     }
 
 }

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
@@ -51,6 +51,10 @@ public class JsonReferenceProposalProvider {
     	return contextTypes;
     }
 
+    public boolean canProvideProposal(JsonPointer pointer) {
+        return pointer != null && contextTypes.get(pointer.toString()) != ContextType.UNKNOWN;
+    }
+
     /**
      * Returns collection of JSON reference proposals.
      * 
@@ -74,14 +78,14 @@ public class JsonReferenceProposalProvider {
         final List<Proposal> proposals = Lists.newArrayList();
 
         if (scope == Scope.LOCAL) {
-            proposals.addAll(collectProposals(doc, type.value(), null));
-        } else {
+            proposals.addAll(type.collectProposals(doc, null));
+        } else if (!type.isLocalOnly()) {
             final SwaggerFileFinder fileFinder = new SwaggerFileFinder(fileContentType);
 
             for (IFile file : fileFinder.collectFiles(scope, currentFile)) {
                 IPath relative = file.equals(currentFile) ? null : file.getFullPath().makeRelativeTo(basePath);
                 JsonNode content = file.equals(currentFile) ? doc : manager.getDocument(file.getLocationURI());
-                proposals.addAll(collectProposals(content, type.value(), relative));
+                proposals.addAll(type.collectProposals(content, relative));
             }
         }
 
@@ -98,11 +102,20 @@ public class JsonReferenceProposalProvider {
         private final String value;
         private final String label;
 		private final String regex;
+        private final boolean isLocalOnly;
 
         public ContextType(String value, String label, String regex) {
             this.value = value;
             this.label = label;
 			this.regex = regex;
+            this.isLocalOnly = false;
+        }
+
+        public ContextType(String value, String label, String regex, boolean isLocalOnly) {
+            this.value = value;
+            this.label = label;
+            this.regex = regex;
+            this.isLocalOnly = isLocalOnly;
         }
 
         public String value() {
@@ -112,7 +125,43 @@ public class JsonReferenceProposalProvider {
         public String label() {
             return label;
         }
-        
+
+        public boolean isLocalOnly() {
+            return isLocalOnly;
+        }
+
+        /**
+         * Returns all proposals found in the document at the specified field.
+         * 
+         * @param document
+         * @param fieldName
+         * @param path
+         * @return Collection of proposals
+         */
+        public Collection<Proposal> collectProposals(JsonNode document, IPath path) {
+            final Collection<Proposal> results = Lists.newArrayList();
+            if (value() == null) {
+                return results;
+            }
+
+            final JsonNode parameters = ValidationUtil.findNode(value(), document);
+            if (parameters == null) {
+                return results;
+            }
+
+            final String basePath = (path != null ? path.toString() : "") + "#/" + value() + "/";
+
+            for (Iterator<String> it = parameters.fieldNames(); it.hasNext();) {
+                String key = it.next();
+                String value = basePath + key.replaceAll("/", "~1");
+                String encoded = URLUtils.encodeURL(value);
+
+                results.add(new Proposal("\"" + encoded + "\"", key, null, value));
+            }
+
+            return results;
+        }
+
         public static ContextTypeCollection newContentTypeCollection(Iterable<ContextType> contextTypes) {
         	return new ContextTypeCollection(contextTypes);
         }
@@ -121,7 +170,39 @@ public class JsonReferenceProposalProvider {
 			return new ContextTypeCollection(Collections.<ContextType>emptyList());
 		}
     }
-    
+
+    public static class ContextTypeValue extends ContextType {
+
+        public ContextTypeValue(String value, String label, String regex) {
+            super(value, label, regex);
+        }
+
+        public ContextTypeValue(String value, String label, String regex, boolean isLocalOnly) {
+            super(value, label, regex, isLocalOnly);
+        }
+
+        @Override
+        public Collection<Proposal> collectProposals(JsonNode document, IPath path) {
+            final Collection<Proposal> results = Lists.newArrayList();
+            if (value() == null) {
+                return results;
+            }
+
+            final List<JsonNode> parameters = document.findValues(value());
+            if (parameters == null) {
+                return results;
+            }
+
+            for (JsonNode node : parameters) {
+                String key = node.asText();
+
+                results.add(new Proposal(key, key, null, key));
+            }
+
+            return results;
+        }
+    }
+
     public static class ContextTypeCollection {
     	
     	private final Iterable<ContextType> contextTypes;
@@ -141,37 +222,6 @@ public class JsonReferenceProposalProvider {
 			}
 			return ContextType.UNKNOWN;
 		}
-    }
-
-    /**
-     * Returns all proposals found in the document at the specified field.
-     * 
-     * @param document
-     * @param fieldName
-     * @param path
-     * @return Collection of proposals
-     */
-    public Collection<Proposal> collectProposals(JsonNode document, String fieldName, IPath path) {
-        final Collection<Proposal> results = Lists.newArrayList();
-        if (fieldName == null) {
-            return results;
-        }
-
-		final JsonNode parameters = ValidationUtil.findNode(fieldName, document);
-        if (parameters == null) {
-        	return results;
-        }
-        final String basePath = (path != null ? path.toString() : "") + "#/" + fieldName + "/";
-
-        for (Iterator<String> it = parameters.fieldNames(); it.hasNext();) {
-            String key = it.next();
-            String value = basePath + key.replaceAll("/", "~1");
-            String encoded = URLUtils.encodeURL(value);
-
-            results.add(new Proposal("\"" + encoded + "\"", key, null, value));
-        }
-
-        return results;
     }
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -32,6 +32,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     protected static final String RESPONSE_REGEX = ".*/responses/\\d+/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
     protected static final String LINK_REGEX = ".*/links/"+COMPONENT_NAME_REGEX +"/\\$ref";
+    protected static final String LINK_OPERATIONID_REGEX = ".*/links/" + COMPONENT_NAME_REGEX + "/operationId";
     protected static final String EXAMPLE_REGEX = ".*/examples/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String SCHEMA_EXAMPLE_REGEX = SCHEMA_COMPONENT_REGEX + "example/\\$ref" + "|"
             + INLINE_SCHEMA_REGEX + "example/\\$ref";
@@ -52,7 +53,11 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     //public static final ContextType SCHEMA_EXAMPLE = new ContextType("its/not/example/component", "example", SCHEMA_EXAMPLE_REGEX);
     public static final ContextType HEADER = new ContextType("components/headers", "header", HEADER_REGEX);
     public static final ContextType CALLBACK = new ContextType("components/callbacks", "callback", CALLBACK_REGEX);
-   
+    public static final ContextType PATH_LINK_OPERATION_ID = new ContextType("components/links/", "operationId",
+            CALLBACK_REGEX);
+    public static final ContextType LINK_OPERATIONID = new ContextTypeValue("operationId", "operationId",
+            LINK_OPERATIONID_REGEX, true);
+
     public static final ContextTypeCollection OPEN_API3_CONTEXT_TYPES = ContextType
             .newContentTypeCollection(Lists.newArrayList( //
                   //  SCHEMA_EXAMPLE, // should go before schema definition
@@ -64,7 +69,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
                     PATH_LINK, //
                     EXAMPLE, //
                     HEADER, //
-                    CALLBACK//
-                    ));
+                    CALLBACK, //
+                    LINK_OPERATIONID));
 
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/JsonReferenceProposalProviderTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/JsonReferenceProposalProviderTest.xtend
@@ -20,6 +20,7 @@ import static org.hamcrest.core.IsCollectionContaining.*
 import static org.junit.Assert.*
 import com.reprezen.swagedit.core.utils.SwaggerFileFinder.Scope
 import com.reprezen.swagedit.core.assist.Proposal
+import com.reprezen.swagedit.core.assist.JsonReferenceProposalProvider.ContextType
 
 class JsonReferenceProposalProviderTest {
 
@@ -112,7 +113,8 @@ class JsonReferenceProposalProviderTest {
 		document.set(text)
 
 		val path = Mocks.mockPath("../Path With Spaces/Other  Spaces.yaml")
-		val proposals = provider.collectProposals(document.asJson, "paths", path)
+		val contextType = new ContextType("paths", "paths", "")
+		val proposals = contextType.collectProposals(document.asJson, path)
 
 		assertThat(proposals, hasItems(
 			new Proposal(


### PR DESCRIPTION
See #307 

I added a new kind of ContextType and moved the collectProposals method inside ContextType. The new ContextTypeValue class overrides the previous logic in collectProposals to retrieve only values found for certain keys (here operationId).

I also added a new property in ContextType to indicate that collection of proposals should only be done in local file.

Tests are currently missing.