### PR TITLE
[#320] Code assist for callbacks in an operation creates an invalid o…

### DIFF
--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessorTest.xtend
@@ -1,0 +1,55 @@
+package com.reprezen.swagedit.openapi3.assist
+
+import com.reprezen.swagedit.core.assist.StyledCompletionProposal
+import com.reprezen.swagedit.openapi3.editor.OpenApi3Document
+import java.util.ArrayList
+import org.junit.Test
+
+import static com.reprezen.swagedit.openapi3.utils.Cursors.*
+import static org.hamcrest.core.IsCollectionContaining.*
+import static org.junit.Assert.*
+import com.reprezen.swagedit.openapi3.schema.OpenApi3Schema
+
+class OpenApi3ContentAssistProcessorTest {
+
+	val processor = new OpenApi3ContentAssistProcessor(null) {
+		override protected initTextMessages() { new ArrayList }
+
+		override protected getContextTypeRegistry() { null }
+
+		override protected getTemplateStore() { null }
+	}
+
+	@Test
+	def void testCallbacksInOperation_ShouldReturnKey() {
+		val document = new OpenApi3Document(new OpenApi3Schema)
+		val test = setUpContentAssistTest('''
+			paths:
+			  /foo:
+			    get:
+			      callbacks:
+			        <1>
+		''', document)
+
+		val proposals = test.apply(processor, "1")		
+		assertThat(proposals.map[(it as StyledCompletionProposal).replacementString], 
+			hasItems("_key_:", "x-:")
+		)
+	}
+
+	@Test
+	def void testCallbacksInComponents_ShouldReturnKey() {
+		val document = new OpenApi3Document(new OpenApi3Schema)
+		val test = setUpContentAssistTest('''
+			components:
+			  callbacks:
+			    <1>
+		''', document)
+
+		val proposals = test.apply(processor, "1")		
+		assertThat(proposals.map[(it as StyledCompletionProposal).replacementString], 
+			hasItems("_key_:")
+		)
+	}
+
+}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Cursors.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Cursors.xtend
@@ -1,0 +1,82 @@
+package com.reprezen.swagedit.openapi3.utils
+
+import com.fasterxml.jackson.core.JsonPointer
+import com.reprezen.swagedit.openapi3.editor.OpenApi3Document
+import java.util.HashMap
+import org.eclipse.jface.text.Document
+import org.eclipse.jface.text.IRegion
+import org.eclipse.jface.text.Region
+import org.eclipse.jface.text.contentassist.ICompletionProposal
+import org.eclipse.jface.text.contentassist.IContentAssistProcessor
+import org.eclipse.xtext.xbase.lib.Functions.Function2
+import org.eclipse.xtext.xbase.lib.Procedures.Procedure2
+
+import static org.junit.Assert.*
+
+class Cursors {
+
+	static def (String, String)=>void setUpPathTest(String yaml, OpenApi3Document doc) {
+		val groups = groupMarkers(yaml)
+		doc.set(removeMarkers(yaml))
+		doc.onChange
+
+		new Procedure2<String, String>() {
+			override apply(String path, String marker) {
+				assertEquals(JsonPointer.compile(path), doc.getPath(groups.get(marker)))
+			}
+		}
+	}
+
+	static def (IContentAssistProcessor, String)=>ICompletionProposal[] setUpContentAssistTest(String yaml,
+		OpenApi3Document doc) {
+
+		val groups = groupMarkers(yaml)
+		doc.set(removeMarkers(yaml))
+		doc.onChange
+
+		new Function2<IContentAssistProcessor, String, ICompletionProposal[]>() {
+			override ICompletionProposal[] apply(IContentAssistProcessor processor, String marker) {
+				// TODO check why we need to add +1 to offset here
+				val offset = groups.get(marker).offset + 1
+				val viewer = Mocks.mockTextViewer(doc, offset)
+
+				processor.computeCompletionProposals(viewer, offset)
+			}
+		}
+	}
+
+	static def groupMarkers(String text) {
+		val groups = new HashMap<String, IRegion>
+
+		val doc = new Document(text)
+		var i = 0
+		var offset = 0
+		var start = false
+		var group = ""
+
+		while (i < doc.getLength()) {
+			var current = doc.get(i, 1)
+			if (current.equals("<")) {
+				start = true
+			} else if (current.equals(">")) {
+				start = false
+				groups.put(group, new Region(Math.max(0, offset - 1), 1))
+				group = ""
+			} else {
+				if (start) {
+					group += current
+				} else {
+					offset++
+				}
+			}
+			i++
+		}
+
+		groups
+	}
+
+	protected static def removeMarkers(String content) {
+		content.replaceAll("<\\d+>", "")
+	}
+
+}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Mocks.java
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Mocks.java
@@ -1,0 +1,36 @@
+package com.reprezen.swagedit.openapi3.utils;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.eclipse.jface.text.ITextSelection;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.viewers.ISelectionProvider;
+import org.eclipse.swt.graphics.Point;
+
+import com.reprezen.swagedit.openapi3.editor.OpenApi3Document;
+
+public class Mocks {
+
+    public static ITextViewer mockTextViewer(OpenApi3Document document, int offset) {
+        ITextViewer viewer = mock(ITextViewer.class);
+        ISelectionProvider selectionProvider = mockSelectionProvider();
+        ITextSelection selection = mockSelection();
+
+        when(viewer.getDocument()).thenReturn(document);
+        when(viewer.getSelectedRange()).thenReturn(new Point(0, 0));
+        when(viewer.getSelectionProvider()).thenReturn(selectionProvider);
+        when(selectionProvider.getSelection()).thenReturn(selection);
+        when(selection.getOffset()).thenReturn(offset);
+
+        return viewer;
+    }
+
+    public static ISelectionProvider mockSelectionProvider() {
+        return mock(ISelectionProvider.class);
+    }
+
+    public static ITextSelection mockSelection() {
+        return mock(ITextSelection.class);
+    }
+}

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessor.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessor.java
@@ -16,12 +16,13 @@ import org.eclipse.jface.text.templates.persistence.TemplateStore;
 import com.reprezen.swagedit.core.assist.JsonContentAssistProcessor;
 import com.reprezen.swagedit.core.assist.JsonProposalProvider;
 import com.reprezen.swagedit.openapi3.Activator;
+import com.reprezen.swagedit.openapi3.assist.ext.CallbacksContentAssistExt;
 import com.reprezen.swagedit.openapi3.templates.OpenApi3ContextType;
 
 public class OpenApi3ContentAssistProcessor extends JsonContentAssistProcessor {
 
 	public OpenApi3ContentAssistProcessor(ContentAssistant ca) {
-		super(ca, new JsonProposalProvider(), new OpenApi3ReferenceProposalProvider());
+        super(ca, new JsonProposalProvider(new CallbacksContentAssistExt()), new OpenApi3ReferenceProposalProvider());
 	}
 
 	@Override

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/ext/CallbacksContentAssistExt.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/ext/CallbacksContentAssistExt.java
@@ -1,0 +1,28 @@
+package com.reprezen.swagedit.openapi3.assist.ext;
+
+import java.util.Collection;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.google.common.collect.Lists;
+import com.reprezen.swagedit.core.assist.Proposal;
+import com.reprezen.swagedit.core.assist.ext.ContentAssistExt;
+import com.reprezen.swagedit.core.model.AbstractNode;
+import com.reprezen.swagedit.core.schema.TypeDefinition;
+
+public class CallbacksContentAssistExt implements ContentAssistExt {
+
+    private final JsonPointer pointer = JsonPointer.compile("/definitions/callbacks");
+
+    @Override
+    public boolean canProvideContentAssist(TypeDefinition type) {
+        return type != null && pointer.equals(type.getPointer());
+    }
+
+    @Override
+    public Collection<Proposal> getProposals(TypeDefinition type, AbstractNode node, String prefix) {
+        return Lists.newArrayList( //
+                new Proposal("_key_:", "_key_", null, "callbackOrReference"), //
+                new Proposal("x-:", "x-", null, "specificationExtension"));
+    }
+
+}

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Document.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Document.java
@@ -12,11 +12,16 @@ package com.reprezen.swagedit.openapi3.editor;
 
 import com.reprezen.swagedit.core.editor.JsonDocument;
 import com.reprezen.swagedit.openapi3.Activator;
+import com.reprezen.swagedit.openapi3.schema.OpenApi3Schema;
 
 public class OpenApi3Document extends JsonDocument {
 
 	public OpenApi3Document() {
-		super(io.swagger.util.Yaml.mapper(), Activator.getDefault().getSchema());
+        this(Activator.getDefault().getSchema());
 	}
+
+    public OpenApi3Document(OpenApi3Schema schema) {
+        super(io.swagger.util.Yaml.mapper(), schema);
+    }
 
 }


### PR DESCRIPTION
…bject

See #320 

Fixed by using a ContentAssistExt to override default behaviour of content assist for callbacks in operations.