### PR TITLE
#289, #301 Tests+fixes  for reference context assist

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonContentAssistProcessor.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonContentAssistProcessor.java
@@ -184,7 +184,7 @@ public abstract class JsonContentAssistProcessor extends TemplateCompletionProce
 		IBindingService bindingService = (IBindingService) PlatformUI.getWorkbench().getAdapter(IBindingService.class);
 		String bindingKey = bindingService.getBestActiveBindingFormattedFor(EDIT_CONTENT_ASSIST);
 
-		ContextType contextType = referenceProposalProvider.getContextTypes().get(getCurrentPath() != null ? getCurrentPath().toString() : "");
+		ContextType contextType = referenceProposalProvider.getContextTypes().get(getCurrentPath());
 		String context = contextType != null ? contextType.label() : "";
 
 		return new String[] { //

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonReferenceProposalProvider.java
@@ -49,7 +49,7 @@ public class JsonReferenceProposalProvider {
     }
 
     public boolean canProvideProposal(JsonPointer pointer) {
-        return pointer != null && contextTypes.get(pointer.toString()) != ContextType.UNKNOWN;
+        return pointer != null && contextTypes.get(pointer) != ContextType.UNKNOWN;
     }
 
     /**
@@ -69,7 +69,7 @@ public class JsonReferenceProposalProvider {
      * @return proposals
      */
     public Collection<Proposal> getProposals(JsonPointer pointer, JsonDocument document, Scope scope) {
-        final ContextType type = contextTypes.get(pointer.toString());
+        final ContextType type = contextTypes.get(pointer);
         final IFile currentFile = getActiveFile();
         final IPath basePath = currentFile.getParent().getFullPath();
         final List<Proposal> proposals = Lists.newArrayList();

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/contexts/ContextType.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/contexts/ContextType.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 
 import org.eclipse.core.runtime.IPath;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Lists;
 import com.reprezen.swagedit.core.assist.Proposal;
@@ -22,7 +23,7 @@ public class ContextType {
 
     private final String value;
     private final String label;
-    final String regex;
+    private final String regex;
     private final boolean isLocalOnly;
 
     public ContextType(String value, String label, String regex) {
@@ -37,6 +38,13 @@ public class ContextType {
         this.label = label;
         this.regex = regex;
         this.isLocalOnly = isLocalOnly;
+    }
+    
+    public boolean canProvideProposal(JsonPointer pointer) {
+        if (pointer != null && regex != null) {
+            return pointer.toString().matches(regex);
+        }
+        return false;
     }
 
     public String value() {

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/contexts/ContextTypeCollection.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/contexts/ContextTypeCollection.java
@@ -1,6 +1,6 @@
 package com.reprezen.swagedit.core.assist.contexts;
 
-import com.google.common.base.Strings;
+import com.fasterxml.jackson.core.JsonPointer;
 
 public class ContextTypeCollection {
 
@@ -10,12 +10,9 @@ public class ContextTypeCollection {
         this.contextTypes = contextTypes;
     }
 
-    public ContextType get(String path) {
-        if (Strings.emptyToNull(path) == null) {
-            return ContextType.UNKNOWN;
-        }
+    public ContextType get(JsonPointer pointer) {
         for (ContextType next : contextTypes) {
-            if (path.matches(next.regex)) {
+            if (next.canProvideProposal(pointer)) {
                 return next;
             }
         }

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/code-templates/CallbacksObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/code-templates/CallbacksObject.yaml
@@ -1,0 +1,37 @@
+openapi: "3.0.0"
+info:
+  title: Callbacks Object
+  version: "1.0.0"  
+  
+paths: 
+
+  /pets:
+    get:
+      summary: Read
+      description: Provide details for the entire list (for collection resources) or an item (for object resources)
+      responses: {}
+      callbacks:
+        #KZOE-template name="callbacks in operation", value="callbacks"
+        myWebhook:
+          $ref: "#/components/callbacks/myWebhook"
+
+components: 
+
+  callbacks:
+    #KZOE-template name="callbacks in components/callbacks", value="callbacks"
+    MyWebhooWithRef:
+      $ref: "#/components/callbacks/myWebhook"
+    myWebhook:
+      '$request.body#/url':
+        post:
+          requestBody:
+            description: Callback payload
+            content: 
+              'application/json':
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: webhook successfully processed and no retries will be performed
+
+ 

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/CallbacksObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/CallbacksObject.yaml
@@ -12,12 +12,15 @@ paths:
       responses: {}
       callbacks:
         myWebhook:
-         # Operation: KaiZen code assist OK
+          #KZOE-ref name="callback in operation", value="components/callbacks"
           $ref: "#/components/callbacks/myWebhook"
 
 components: 
 
   callbacks:
+    MyWebhooWithRef:
+      #KZOE-ref name="callback in components/callback", value="components/callbacks"
+      $ref: "#/components/callbacks/myWebhook"
     myWebhook:
       '$request.body#/url':
         post:

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ExamplesObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ExamplesObject.yaml
@@ -15,13 +15,12 @@ paths:
         schema:
           type: 'string'
           format: 'zip-code'
-          # KaiZen code-assist shows examples here
           example: 
             $ref: 'http://foo.bar#/examples/zip-example'
         
     put:
       description: bla
-      operationId: sd
+      operationId: opId
       responses: {}
       requestBody:  
         description: description
@@ -52,6 +51,7 @@ paths:
                 value: {"bar": "baz"}
                 # KaiZen code assist OK here
               pizza:
+                #KZOE-ref name="example in requestBody content schema", value="components/examples"
                 $ref: "#/components/examples/confirmation-success"           
                    
           'application/xml':
@@ -74,7 +74,7 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
               examples:
                 confirmation-success:
-                # KaiZen: code-assist OK here
+                  #KZOE-ref name="example in response content schema", value="components/examples"
                   $ref: '#/components/examples/confirmation-success'
       
 components:

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ExamplesObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ExamplesObject.yaml
@@ -15,8 +15,11 @@ paths:
         schema:
           type: 'string'
           format: 'zip-code'
-          example: 
-            $ref: 'http://foo.bar#/examples/zip-example'
+        examples:
+          pizza:
+            #KZOE-ref name="example in parameter", value="components/examples"
+            $ref: "#/components/examples/confirmation-success"
+           
         
     put:
       description: bla
@@ -51,7 +54,7 @@ paths:
                 value: {"bar": "baz"}
                 # KaiZen code assist OK here
               pizza:
-                #KZOE-ref name="example in requestBody content schema", value="components/examples"
+                #KZOE-ref name="example in requestBody content", value="components/examples"
                 $ref: "#/components/examples/confirmation-success"           
                    
           'application/xml':
@@ -74,7 +77,7 @@ paths:
                 $ref: '#/components/schemas/SuccessResponse'
               examples:
                 confirmation-success:
-                  #KZOE-ref name="example in response content schema", value="components/examples"
+                  #KZOE-ref name="example in response content", value="components/examples"
                   $ref: '#/components/examples/confirmation-success'
       
 components:

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ExamplesObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ExamplesObject.yaml
@@ -89,5 +89,8 @@ components:
              $ref: http://foo.bar#/examples/name-example
             
   examples: 
+    refed:
+      #KZOE-ref name="example in components/examples", value="components/examples"
+      $ref: '#/components/examples/confirmation-success'
     confirmation-success:
       summary: this is confirmation success example

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/HeadersObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/HeadersObject.yaml
@@ -29,7 +29,7 @@ paths:
               schema:
                 type: integer
             X-Rate-Limit-Reset:
-            # In Responses: KaiZen code assist OK
+              #KZOE-ref name="header in response", value="components/headers"
               $ref: "#/components/headers/X-Rate-Limit-Reset"   
 
 components: 
@@ -45,6 +45,6 @@ components:
       operationId: getRepositoriesByOwner
       headers:
         X-Rate-Limit-Reset:
-          # In Links: KaiZen code assist OK
+          #KZOE-ref name="header in links", value="components/headers"
           $ref: "#/components/headers/X-Rate-Limit-Reset"
  

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/HeadersObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/HeadersObject.yaml
@@ -33,8 +33,12 @@ paths:
               $ref: "#/components/headers/X-Rate-Limit-Reset"   
 
 components: 
-
   headers:
+  
+    refed:
+      #KZOE-ref name="header in components/headers", value="components/headers"
+      $ref: "#/components/headers/X-Rate-Limit-Reset"
+
     X-Rate-Limit-Reset:
       description: The number of seconds left in the current period
       schema:

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/LinksObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/LinksObject.yaml
@@ -23,7 +23,7 @@ paths:
                 $ref: '#/components/schemas/user'
           links:
             userRepositories:
-             ## KaiZen code-assist OK
+              #KZOE-ref name="link in response", value="components/links"
               $ref: '#/components/links/UserRepositories'
               
   /2.0/repositories/{username}:
@@ -46,7 +46,7 @@ paths:
                   $ref: '#/components/schemas/repository'
           links:
             userRepository:
-              ## KaiZen code-assist OK
+              #KZOE-ref name="link in response 2", value="components/links"
               $ref: '#/components/links/UserRepository'
               
   /2.0/repositories/{username}/{slug}: 
@@ -72,7 +72,7 @@ paths:
                   $ref: '#/components/schemas/repository'
           links:
             repositoryPullRequests:
-               # KaiZen code-assist OK
+              #KZOE-ref name="link in response 3", value="components/links"
               $ref: '#/components/links/RepositoryPullRequests'
               
   /2.0/repositories/{username}/{slug}/pullrequests: 
@@ -164,6 +164,9 @@ paths:
 components:
 
   links:
+    linkWithRef:
+      #KZOE-ref name="link in components/links", value="components/links"
+      $ref: ""
     UserRepositories:
       # returns array of '#/components/schemas/repository'
       operationId: getRepositoriesByOwner

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/Parameter.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/Parameter.yaml
@@ -9,9 +9,11 @@ paths:
 
   /pets:
     parameters:
+      #KZOE-ref name="parameter in path item", value="components/parameters" kzoe-arrayItem 
      - $ref: "#/components/parameters/username"
     get:
       parameters:
+        #KZOE-ref name="parameter in operation", value="components/parameters" kzoe-arrayItem 
         - $ref: "#/components/parameters/id"
       summary: Read
       description: Provide details for the entire list (for collection resources) or an item (for object resources)
@@ -22,6 +24,9 @@ paths:
 components: 
 
   parameters:
+    test:
+      #KZOE-ref name="parameter in components/parameters", value="components/parameters"
+      $ref: "#/components/parameters/id"
     # header parameter
     token:
       name: token

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/PathItem.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/PathItem.yaml
@@ -6,6 +6,7 @@ info:
 paths: 
 
   /pets:
+    #KZOE-ref name="path item in paths in components/links", value="paths"
     $ref: "HeadersObject.yaml#/paths/~1pets"
       
 components: 
@@ -13,6 +14,7 @@ components:
   callbacks:
     myWebhook:
       '$request.body#/url':
+        #KZOE-ref name="path item in callback", value="paths"
         $ref: "HeadersObject.yaml#/paths/~1pets"
 
  

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/PathItem.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/PathItem.yaml
@@ -6,7 +6,7 @@ info:
 paths: 
 
   /pets:
-    #KZOE-ref name="path item in paths in components/links", value="paths"
+    #KZOE-ref name="path item in paths", value="paths"
     $ref: "HeadersObject.yaml#/paths/~1pets"
       
 components: 

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/RequestBody.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/RequestBody.yaml
@@ -12,7 +12,7 @@ paths:
       summary: Create
       description: Create a new item
       requestBody:
-        #KZOE-ref name="requestBody in operation", value="components/requestBodies"
+        #KZOE-ref name="requestBody in path item operation", value="components/requestBodies"
         $ref: "#/components/requestBodies/forPost"
       responses:
         '200':

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/RequestBody.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/RequestBody.yaml
@@ -30,6 +30,9 @@ components:
           responses: {}
               
   requestBodies:
+    refed:
+      #KZOE-ref name="requestBody in components/requestBodies", value="components/requestBodies"
+      $ref: "#/components/requestBodies/www-form-urlencoded"
   
     forPost:
       content:

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/RequestBody.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/RequestBody.yaml
@@ -12,6 +12,7 @@ paths:
       summary: Create
       description: Create a new item
       requestBody:
+        #KZOE-ref name="requestBody in operation", value="components/requestBodies"
         $ref: "#/components/requestBodies/forPost"
       responses:
         '200':
@@ -24,6 +25,7 @@ components:
       '$request.body#/url':
         post:
           requestBody:
+            #KZOE-ref name="requestBody in callback", value="components/requestBodies"
             $ref: "#/components/requestBodies/www-form-urlencoded"
           responses: {}
               

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ResponseObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/ResponseObject.yaml
@@ -1,0 +1,26 @@
+openapi: "3.0.0"
+info:
+  title: Response Object
+  version: "1.0.0"
+  
+paths: 
+
+  /pets:
+    get:
+      summary: Read
+      description: Provide
+      responses:
+        '200':
+          #KZOE-ref name="response operation 200", value="components/responses"
+          $ref: "#/components/responses/clientErrorResponse"
+        default:
+           #KZOE-ref name="response in operation default", value="components/responses"
+          $ref: "#/components/responses/clientErrorResponse"
+          
+components:
+  responses:
+    clientErrorResponse:
+      description: Client error
+    circular:
+       #KZOE-ref name="response in components/responses", value="components/responses"
+      $ref: "#/components/responses/clientErrorResponse"

--- a/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/SchemaObject.yaml
+++ b/com.reprezen.swagedit.openapi3.tests/resources/code-assist/references/SchemaObject.yaml
@@ -1,0 +1,121 @@
+openapi: "3.0.0"
+info:
+  title: Schema Object
+  version: "1.0.0"
+  
+paths:
+  /resource:
+    get:
+      description: description
+      responses:
+        '200':
+          description: Ok
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  #KZOE-ref name="schema in content array", value="components/schemas"
+                  $ref: '#/components/schemas/StringToModelMappingObject'
+            '*/*' :
+               schema: 
+                 #KZOE-ref name="schema in content", value="components/schemas"
+                 $ref: "#/components/schemas/SimpleObject"
+          
+components:
+  schemas:
+  
+    SimpleObject:
+      type: object
+      required:
+      - name
+      properties:
+        name:
+          type: string
+        address:
+          #KZOE-ref name="schema in properties", value="components/schemas"
+          $ref: "#/components/schemas/Pet"
+        age:
+          type: integer
+          format: int32
+          minimum: 0    
+        
+    StringToModelMappingObject:
+      type: object
+      additionalProperties:
+        #KZOE-ref name="schema in additionalProperties", value="components/schemas"
+        $ref: "#/components/schemas/Dog"
+        
+    ExtendedErrorModel:
+      allOf:
+        #KZOE-ref name="schema in allOf", value="components/schemas" kzoe-arrayItem
+      - $ref: '#/components/schemas/ErrorModel'
+      - type: object
+        required:
+        - rootCause
+        properties:
+          rootCause:
+            type: string
+            
+    WithAnyOf:  ## 
+      description: A representation of a cat
+      anyOf:
+        #KZOE-ref name="schema in anyOf", value="components/schemas" kzoe-arrayItem
+      - $ref: '#/components/schemas/Pet'
+      - type: object
+        properties:
+          huntingSkill:
+            type: string
+            description: The measured skill for hunting
+            enum:
+            - clueless
+            - lazy
+            - adventurous
+            - aggressive
+        required:
+        - huntingSkill
+ 
+    AnyOfWithNestedSchema:  ## 
+      description: A representation of a cat
+      anyOf:
+      - type: object
+        properties:
+          huntingSkill:
+            #KZOE-ref name="schema in anyOf", value="components/schemas" kzoe-arrayItem
+            $ref: "#/components/schemas/SimpleObject"
+                
+    # Discrinimator Object
+    MyResponseType:
+      oneOf:
+        #KZOE-ref name="schema in oneOf", value="components/schemas" kzoe-arrayItem
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Lizard'
+      discriminator:
+          propertyName: pet_type       
+          
+          
+    SchemaItems:
+      type: array
+      items:
+        #KZOE-ref name="schema in items", value="components/schemas" kzoe-arrayItem
+        $ref: ""
+
+  parameters:
+    username:
+      name: username
+      in: path
+      description: username to fetch
+      required: true
+      schema:
+        #KZOE-ref name="schema in parameter", value="components/schemas"
+        $ref: "#/components/schemas/SimpleObject"
+           
+  headers:
+    X-Rate-Limit-Reset:
+      description: The number of seconds left in the current period
+      schema:
+        #KZOE-ref name="schema in header", value="components/schemas"
+        $ref: "#/components/schemas/SimpleObject"    
+                     
+  

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/CodeAssistContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/CodeAssistContextTest.xtend
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.openapi3.assist
+
+import com.google.common.base.Charsets
+import java.io.File
+import java.io.FilenameFilter
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.util.ArrayList
+import java.util.Collection
+import java.util.List
+import java.util.regex.Pattern
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameter
+
+@RunWith(typeof(Parameterized))
+abstract class CodeAssistContextTest {
+	
+	val static testNamePattern = Pattern::compile(".*name=\"([\\w\\s/]+)\".*")
+	val protected static refValuePattern = Pattern::compile(".*value=\"([\\w\\s/]+)\".*")
+
+	def static protected Collection<Object[]> data(File resourcesDir, String contextMarker) {
+		val specFiles = resourcesDir.listFiles(new FilenameFilter() {
+
+			override accept(File dir, String name) {
+				name.endsWith(".yaml")
+			}
+
+		})
+		val Collection<Object[]> result = new ArrayList<Object[]>()
+		for (File specFile : specFiles) {
+			val fileContents = fileContents(specFile)
+			val indices = getAllIndicesOf(fileContents, contextMarker)
+			indices.forEach[result.add(#[specFile, specFile.name, it, getTestName(fileContents, it)] as Object[])]
+
+		}
+		return result
+	}
+
+	@Parameter
+	var public File specFile
+
+	@Parameter(1)
+	var public String fileName // for test name only
+	
+	@Parameter(2)
+	var public int offset // for test name only
+	
+	@Parameter(3)
+	var public String testName // for test name only
+
+	def public static List<Integer> getAllIndicesOf(String str, String substring) {
+		val result = newArrayList()
+		var index = str.indexOf(substring)
+		while (index > 0) {
+			result.add(index)
+			index = str.indexOf(substring, index + 1)
+		}
+		return result
+	}
+
+	def public static String fileContents(File file) {
+		return new String(Files.readAllBytes(Paths.get(file.getPath)), Charsets.UTF_8);
+	}
+	
+	def public static String getTestName(String spec, int offset) {
+		val input = spec.substring(offset, spec.indexOf("\n", offset))
+		val matcher = testNamePattern.matcher(input)
+		if (matcher.matches) {
+			return matcher.group(1)
+		}
+		return "" + offset
+	}
+}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/CodeTemplateContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/CodeTemplateContextTest.xtend
@@ -20,36 +20,36 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
 import static org.junit.Assert.*
+import com.reprezen.swagedit.openapi3.templates.OpenApi3ContextType
 
 @RunWith(typeof(Parameterized))
-class ReferenceContextTest extends CodeAssistContextTest{
+class CodeTemplateContextTest extends CodeAssistContextTest{
 
-	val static KZOEref = "#KZOE-ref"
+	val static KZOEref = "#KZOE-template"
 
 	@Parameters(name="{index}: {1} - {3}")
 	def static Collection<Object[]> data() {
-		val resourcesDir = Paths.get("resources", "code-assist", "references").toFile();
+		val resourcesDir = Paths.get("resources", "code-assist", "code-templates").toFile();
 		return data(resourcesDir, KZOEref)
 	}
 
 	@Test
-	def void test_reference_context() {
+	def void test_code_template_context() {
 		val document = new OpenApi3Document(new OpenApi3Schema())
 		val text = specFile.fileContents()
 		document.set(text)
 
 		val region = document.getLineInformationOfOffset(offset)
 		val line = document.getLineOfOffset(offset)
+		val annotationLine = document.get(region.offset, region.getLength())
 
 		val path = document.getModel(offset).getPath(line, document.getColumnOfOffset(line, region))
-		val allContextTypes = OpenApi3ReferenceProposalProvider.OPEN_API3_CONTEXT_TYPES
-		val contextType = allContextTypes.get(path.toString + "/$ref")
-
-		val annotationLine = document.get(region.offset, region.getLength())
+		val templateContext = OpenApi3ContextType.getContextType(path.toString)
 		val matcher = refValuePattern.matcher(annotationLine)
 		if (matcher.matches) {
 			val String refValue = matcher.group(1);
-			assertEquals(refValue, contextType.value);
+			assertNotNull("Code-template context is null, but expected: " + refValue, templateContext)
+			assertEquals(refValue, templateContext.name);
 		} else {
 			fail("Invalid test annotation line: " + annotationLine)
 		}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/ReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/ReferenceContextTest.xtend
@@ -25,6 +25,7 @@ import static org.junit.Assert.*
 class ReferenceContextTest extends CodeAssistContextTest{
 
 	val static KZOEref = "#KZOE-ref"
+	val arrayItemMarker = "kzoe-arrayItem"
 
 	@Parameters(name="{index}: {1} - {3}")
 	def static Collection<Object[]> data() {
@@ -40,12 +41,14 @@ class ReferenceContextTest extends CodeAssistContextTest{
 
 		val region = document.getLineInformationOfOffset(offset)
 		val line = document.getLineOfOffset(offset)
+		val annotationLine = document.get(region.offset, region.getLength())
 
 		val path = document.getModel(offset).getPath(line, document.getColumnOfOffset(line, region))
 		val allContextTypes = OpenApi3ReferenceProposalProvider.OPEN_API3_CONTEXT_TYPES
-		val contextType = allContextTypes.get(path.toString + "/$ref")
+		val isArrayItem = annotationLine.contains(" " + arrayItemMarker + " ")
+		val maybeArrayPrefix = if (isArrayItem) "/0" else ""
+		val contextType = allContextTypes.get(path.toString + maybeArrayPrefix + "/$ref")
 
-		val annotationLine = document.get(region.offset, region.getLength())
 		val matcher = refValuePattern.matcher(annotationLine)
 		if (matcher.matches) {
 			val String refValue = matcher.group(1);

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/ReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/ReferenceContextTest.xtend
@@ -20,12 +20,15 @@ import org.junit.runners.Parameterized
 import org.junit.runners.Parameterized.Parameters
 
 import static org.junit.Assert.*
+import com.fasterxml.jackson.core.JsonPointer
 
 @RunWith(typeof(Parameterized))
 class ReferenceContextTest extends CodeAssistContextTest{
 
 	val static KZOEref = "#KZOE-ref"
 	val arrayItemMarker = "kzoe-arrayItem"
+
+	val allContextTypes = OpenApi3ReferenceProposalProvider.OPEN_API3_CONTEXT_TYPES
 
 	@Parameters(name="{index}: {1} - {3}")
 	def static Collection<Object[]> data() {
@@ -44,10 +47,9 @@ class ReferenceContextTest extends CodeAssistContextTest{
 		val annotationLine = document.get(region.offset, region.getLength())
 
 		val path = document.getModel(offset).getPath(line, document.getColumnOfOffset(line, region))
-		val allContextTypes = OpenApi3ReferenceProposalProvider.OPEN_API3_CONTEXT_TYPES
 		val isArrayItem = annotationLine.contains(" " + arrayItemMarker + " ")
 		val maybeArrayPrefix = if (isArrayItem) "/0" else ""
-		val contextType = allContextTypes.get(path.toString + maybeArrayPrefix + "/$ref")
+		val contextType = allContextTypes.get(path.append(JsonPointer.compile(maybeArrayPrefix + "/$ref")))
 
 		val matcher = refValuePattern.matcher(annotationLine)
 		if (matcher.matches) {

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/ReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/ReferenceContextTest.xtend
@@ -21,6 +21,7 @@ import org.junit.runners.Parameterized.Parameters
 
 import static org.junit.Assert.*
 import com.fasterxml.jackson.core.JsonPointer
+import com.reprezen.swagedit.openapi3.assist.OpenApi3ReferenceProposalProvider.OpenApi3ContextTypeCollection
 
 @RunWith(typeof(Parameterized))
 class ReferenceContextTest extends CodeAssistContextTest{
@@ -28,7 +29,7 @@ class ReferenceContextTest extends CodeAssistContextTest{
 	val static KZOEref = "#KZOE-ref"
 	val arrayItemMarker = "kzoe-arrayItem"
 
-	val allContextTypes = OpenApi3ReferenceProposalProvider.OPEN_API3_CONTEXT_TYPES
+	val allContextTypes = new OpenApi3ContextTypeCollection(new OpenApi3Schema)
 
 	@Parameters(name="{index}: {1} - {3}")
 	def static Collection<Object[]> data() {

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/ReferenceContextTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/ReferenceContextTest.xtend
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.openapi3.assist
+
+import com.reprezen.swagedit.openapi3.editor.OpenApi3Document
+import org.junit.Test
+
+import static org.junit.Assert.*
+import java.util.regex.Pattern
+import com.reprezen.swagedit.openapi3.schema.OpenApi3Schema
+
+class ReferenceContextTest {
+	val KZOEref = "#KZOE-ref"
+	val testNamePattern = Pattern::compile(".*name=\"([\\w\\s]+)\".*")
+	val refValuePattern = Pattern::compile(".*value=\"([\\w/]+)\".*")
+
+	@Test
+	def void testCallbackRef_in_operation() {
+		val text = '''
+openapi: "3.0.0"
+info:
+  title: Callbacks Object
+  version: "1.0.0"  
+  
+paths: 
+
+  /pets:
+    get:
+      summary: Read
+      description: Provide details for the entire list (for collection resources) or an item (for object resources)
+      responses: {}
+      callbacks:
+        myWebhook:
+          #KZOE-ref name="callback in operation", value="components/callbacks"
+          $ref: "#/components/callbacks/myWebhook"
+
+components: 
+
+  callbacks:
+    myWebhook:
+      '$request.body#/url':
+        post:
+          requestBody:
+            description: Callback payload
+            content: 
+              'application/json':
+                schema:
+                  $ref: '#/components/schemas/SomePayload'
+          responses:
+            '200':
+              description: webhook successfully processed and no retries will be performed
+		'''
+
+		val document = new OpenApi3Document(new OpenApi3Schema())
+		document.set(text)
+		val offset = text.indexOf(KZOEref)
+		val region = document.getLineInformationOfOffset(offset)
+		val line = document.getLineOfOffset(offset)
+
+		val path = document.getModel(offset).getPath(line, document.getColumnOfOffset(line, region))
+		val allContextTypes = OpenApi3ReferenceProposalProvider.OPEN_API3_CONTEXT_TYPES
+		val contextType = allContextTypes.get(path.toString + "/$ref")
+
+		val annotationLine = document.get(region.offset, region.getLength())
+		val matcher = refValuePattern.matcher(annotationLine)
+		if (matcher.matches) {
+			val String refValue = matcher.group(1);
+			assertEquals(refValue, contextType.value);
+		} else {
+			fail("Invalid test annotation line: " + annotationLine)
+		}
+	}
+}

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/Activator.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/Activator.java
@@ -72,7 +72,7 @@ public class Activator extends AbstractUIPlugin {
     public ContextTypeRegistry getContextTypeRegistry() {
         if (contextTypeRegistry == null) {
             contextTypeRegistry = new ContributionContextTypeRegistry();
-            for (String contextType : OpenApi3ContextType.allContextTypes()) {
+            for (String contextType : OpenApi3ContextType.allContextTypeIds()) {
                 contextTypeRegistry.addContextType(contextType);
             }
         }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessor.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessor.java
@@ -37,9 +37,10 @@ public class OpenApi3ContentAssistProcessor extends JsonContentAssistProcessor {
         return Activator.getDefault().getContextTypeRegistry();
 	}
 
-	@Override
-	protected String getContextTypeId(String path) {
-        return OpenApi3ContextType.getContextType(path);
-	}
+    @Override
+    protected String getContextTypeId(String path) {
+        OpenApi3ContextType contextType = OpenApi3ContextType.getContextType(path);
+        return contextType != null ? contextType.getId() : null;
+    }
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -35,7 +35,7 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
             // e.g. "/components/callbacks/myWebhook/$request.body#~1url/$ref"
             + "|/components/callbacks/" + COMPONENT_NAME_REGEX + "/[^/]+/\\$ref"; // in callbacks
     protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
-    protected static final String RESPONSE_REGEX = ".*/responses/([0-9X]{3}|default)/\\$ref";
+    protected static final String RESPONSE_REGEX = ".*/responses/([0-9X]{3}|default)/\\$ref|/components/responses/"+COMPONENT_NAME_REGEX+"/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
     protected static final String LINK_REGEX = ".*/links/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String LINK_OPERATIONID_REGEX = ".*/links/" + COMPONENT_NAME_REGEX + "/operationId";

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -38,7 +38,8 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
             + "|/components/parameters/"+COMPONENT_NAME_REGEX+"/\\$ref";
     protected static final String RESPONSE_REGEX = ".*/responses/([0-9X]{3}|default)/\\$ref"//
             + "|/components/responses/"+COMPONENT_NAME_REGEX+"/\\$ref";
-    protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
+    protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref"//
+            + "|/components/requestBodies/"+COMPONENT_NAME_REGEX+"/\\$ref";
     protected static final String LINK_REGEX = ".*/links/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String LINK_OPERATIONID_REGEX = ".*/links/" + COMPONENT_NAME_REGEX + "/operationId";
     protected static final String LINK_OPERATIONREF_REGEX = ".*/links/" + COMPONENT_NAME_REGEX + "/operationRef";

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -14,6 +14,7 @@ import com.google.common.collect.Lists;
 import com.reprezen.swagedit.core.assist.JsonReferenceProposalProvider;
 import com.reprezen.swagedit.core.assist.contexts.ContextType;
 import com.reprezen.swagedit.core.assist.contexts.ContextTypeCollection;
+import com.reprezen.swagedit.core.schema.CompositeSchema;
 import com.reprezen.swagedit.openapi3.Activator;
 import com.reprezen.swagedit.openapi3.assist.contexts.OperationContextType;
 import com.reprezen.swagedit.openapi3.assist.contexts.OperationIdContextType;
@@ -22,38 +23,38 @@ import com.reprezen.swagedit.openapi3.editor.OpenApi3ContentDescriber;
 
 public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProvider {
 
-	public OpenApi3ReferenceProposalProvider() {
-		super(OPEN_API3_CONTEXT_TYPES, OpenApi3ContentDescriber.CONTENT_TYPE_ID);
-	}
-    
-	protected static final String COMPONENT_NAME_REGEX = "[\\w\\.\\-]+";
-	
+    public OpenApi3ReferenceProposalProvider() {
+        super(new OpenApi3ContextTypeCollection(Activator.getDefault().getSchema()), OpenApi3ContentDescriber.CONTENT_TYPE_ID);
+    }
+
+    protected static final String COMPONENT_NAME_REGEX = "[\\w\\.\\-]+";
+
     protected static final String SCHEMA_COMPONENT_REGEX = "^/components/schemas/(\\w+/)+";
     protected static final String INLINE_SCHEMA_REGEX = ".*schema/(\\w+/)*";
-	protected static final String SCHEMA_DEFINITION_REGEX = SCHEMA_COMPONENT_REGEX + "\\$ref" + "|" + INLINE_SCHEMA_REGEX + "\\$ref";
+    protected static final String SCHEMA_DEFINITION_REGEX = SCHEMA_COMPONENT_REGEX + "\\$ref" + "|"
+            + INLINE_SCHEMA_REGEX + "\\$ref";
     protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref"// in paths object
             // e.g. "/components/callbacks/myWebhook/$request.body#~1url/$ref"
             + "|/components/callbacks/" + COMPONENT_NAME_REGEX + "/[^/]+/\\$ref"; // in callbacks
     protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref"//
-            + "|/components/parameters/"+COMPONENT_NAME_REGEX+"/\\$ref";
+            + "|/components/parameters/" + COMPONENT_NAME_REGEX + "/\\$ref";
     protected static final String RESPONSE_REGEX = ".*/responses/([0-9X]{3}|default)/\\$ref"//
-            + "|/components/responses/"+COMPONENT_NAME_REGEX+"/\\$ref";
+            + "|/components/responses/" + COMPONENT_NAME_REGEX + "/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref"//
-            + "|/components/requestBodies/"+COMPONENT_NAME_REGEX+"/\\$ref";
-    protected static final String LINK_REGEX = ".*/links/"+COMPONENT_NAME_REGEX +"/\\$ref";
+            + "|/components/requestBodies/" + COMPONENT_NAME_REGEX + "/\\$ref";
+    protected static final String LINK_REGEX = ".*/links/" + COMPONENT_NAME_REGEX + "/\\$ref";
     protected static final String LINK_OPERATIONID_REGEX = ".*/links/" + COMPONENT_NAME_REGEX + "/operationId";
     protected static final String LINK_OPERATIONREF_REGEX = ".*/links/" + COMPONENT_NAME_REGEX + "/operationRef";
-    protected static final String EXAMPLE_REGEX = ".*/examples/"+COMPONENT_NAME_REGEX +"/\\$ref";
+    protected static final String EXAMPLE_REGEX = ".*/examples/" + COMPONENT_NAME_REGEX + "/\\$ref";
     protected static final String SCHEMA_EXAMPLE_REGEX = SCHEMA_COMPONENT_REGEX + "example/\\$ref" + "|"
             + INLINE_SCHEMA_REGEX + "example/\\$ref";
-    protected static final String HEADER_REGEX = ".*/headers/"+COMPONENT_NAME_REGEX +"/\\$ref";
-    protected static final String CALLBACK_REGEX = ".*/callbacks/"+COMPONENT_NAME_REGEX +"/\\$ref";
+    protected static final String HEADER_REGEX = ".*/headers/" + COMPONENT_NAME_REGEX + "/\\$ref";
+    protected static final String CALLBACK_REGEX = ".*/callbacks/" + COMPONENT_NAME_REGEX + "/\\$ref";
     protected static final String SECURITY_REGEX = ".*/security/\\d+";
 
-   
-	public static final ContextType SCHEMA_DEFINITION = new ContextType("components/schemas", "schemas",
-			SCHEMA_DEFINITION_REGEX);
-	public static final ContextType PATH_ITEM = new ContextType("paths", "path items", PATH_ITEM_REGEX);
+    public static final ContextType SCHEMA_DEFINITION = new ContextType("components/schemas", "schemas",
+            SCHEMA_DEFINITION_REGEX);
+    public static final ContextType PATH_ITEM = new ContextType("paths", "path items", PATH_ITEM_REGEX);
     public static final ContextType PATH_PARAMETER = new ContextType("components/parameters", "parameters",
             PARAMETER_REGEX);
     public static final ContextType PATH_RESPONSE = new ContextType("components/responses", "responses",
@@ -62,21 +63,17 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
             REQUEST_BODY_REGEX);
     public static final ContextType PATH_LINK = new ContextType("components/links", "link", LINK_REGEX);
     public static final ContextType EXAMPLE = new ContextType("components/examples", "examples", EXAMPLE_REGEX);
-    //public static final ContextType SCHEMA_EXAMPLE = new ContextType("its/not/example/component", "example", SCHEMA_EXAMPLE_REGEX);
+    // public static final ContextType SCHEMA_EXAMPLE = new ContextType("its/not/example/component", "example",
+    // SCHEMA_EXAMPLE_REGEX);
     public static final ContextType HEADER = new ContextType("components/headers", "header", HEADER_REGEX);
     public static final ContextType CALLBACK = new ContextType("components/callbacks", "callback", CALLBACK_REGEX);
     public static final ContextType PATH_LINK_OPERATION_ID = new ContextType("components/links/", "operationId",
             CALLBACK_REGEX);
-    public static final ContextType LINK_OPERATIONID = new OperationIdContextType(Activator.getDefault().getSchema(),
-            LINK_OPERATIONID_REGEX);
-    public static final ContextType LINK_OPERATIONREF = new OperationContextType(Activator.getDefault().getSchema(),
-            LINK_OPERATIONREF_REGEX);
-    public static final ContextType PATH_SECURITY = new SecuritySchemeContextType(Activator.getDefault().getSchema(),
-            SECURITY_REGEX);
+    public static class OpenApi3ContextTypeCollection extends ContextTypeCollection {
 
-    public static final ContextTypeCollection OPEN_API3_CONTEXT_TYPES = ContextType
-            .newContentTypeCollection(Lists.newArrayList( //
-                  //  SCHEMA_EXAMPLE, // should go before schema definition
+        protected OpenApi3ContextTypeCollection(CompositeSchema schema) {
+            super(Lists.newArrayList( //
+                    // SCHEMA_EXAMPLE, // should go before schema definition
                     SCHEMA_DEFINITION, //
                     PATH_ITEM, //
                     PATH_PARAMETER, //
@@ -86,8 +83,11 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
                     EXAMPLE, //
                     HEADER, //
                     CALLBACK, //
-                    PATH_SECURITY, //
-                    LINK_OPERATIONID, //
-                    LINK_OPERATIONREF));
+                    new SecuritySchemeContextType(schema, OpenApi3ReferenceProposalProvider.SECURITY_REGEX), //
+                    new OperationIdContextType(schema, OpenApi3ReferenceProposalProvider.LINK_OPERATIONID_REGEX), //
+                    new OperationContextType(schema, OpenApi3ReferenceProposalProvider.LINK_OPERATIONREF_REGEX)));
+        }
+
+    }
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ReferenceProposalProvider.java
@@ -34,8 +34,10 @@ public class OpenApi3ReferenceProposalProvider extends JsonReferenceProposalProv
     protected static final String PATH_ITEM_REGEX = "/paths/~1[^/]+/\\$ref"// in paths object
             // e.g. "/components/callbacks/myWebhook/$request.body#~1url/$ref"
             + "|/components/callbacks/" + COMPONENT_NAME_REGEX + "/[^/]+/\\$ref"; // in callbacks
-    protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref";
-    protected static final String RESPONSE_REGEX = ".*/responses/([0-9X]{3}|default)/\\$ref|/components/responses/"+COMPONENT_NAME_REGEX+"/\\$ref";
+    protected static final String PARAMETER_REGEX = ".*/parameters/\\d+/\\$ref"//
+            + "|/components/parameters/"+COMPONENT_NAME_REGEX+"/\\$ref";
+    protected static final String RESPONSE_REGEX = ".*/responses/([0-9X]{3}|default)/\\$ref"//
+            + "|/components/responses/"+COMPONENT_NAME_REGEX+"/\\$ref";
     protected static final String REQUEST_BODY_REGEX = ".*/requestBody/\\$ref";
     protected static final String LINK_REGEX = ".*/links/"+COMPONENT_NAME_REGEX +"/\\$ref";
     protected static final String LINK_OPERATIONID_REGEX = ".*/links/" + COMPONENT_NAME_REGEX + "/operationId";

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/templates/OpenApi3ContextType.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/templates/OpenApi3ContextType.java
@@ -105,7 +105,7 @@ public class OpenApi3ContextType extends TemplateContextType {
         }
     }
 
-    private static List<OpenApi3ContextType> allContextTypes = Lists.<OpenApi3ContextType> newArrayList( //
+    private static List<OpenApi3ContextType> allContextTypes = Lists.newArrayList( //
             new RootContextType(), //
             new ContactContextType(), //
             new PathsContextType(), //

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/templates/OpenApi3ContextType.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/templates/OpenApi3ContextType.java
@@ -5,6 +5,9 @@ import java.util.List;
 import org.eclipse.jface.text.templates.GlobalTemplateVariables;
 import org.eclipse.jface.text.templates.TemplateContextType;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 public class OpenApi3ContextType extends TemplateContextType {
@@ -14,7 +17,11 @@ public class OpenApi3ContextType extends TemplateContextType {
     // 'PATH_ITEM_REGEX + "/[^/]+/parameters$"' are supported
     private static final String PARAMETERS_LIST_REGEX = PATH_ITEM_REGEX + "/([^/]+/)?parameters";
 
-    public OpenApi3ContextType() {
+    private final String regex;
+
+    public OpenApi3ContextType(String name, String regex) {
+        super("com.reprezen.swagedit.openapi3.templates." + name);
+        this.regex = regex;
         addGlobalResolvers();
     }
 
@@ -30,107 +37,112 @@ public class OpenApi3ContextType extends TemplateContextType {
     }
 
     public static class RootContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.root";
+        public RootContextType() {
+            super("root", "");
+        }
     }
 
     public static class ContactContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.info.contact";
+        public ContactContextType() {
+            super("info.contact", "/info/contact");
+        }
     }
 
     public static class PathsContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.paths";
+        public PathsContextType() {
+            super("paths", "/paths");
+        }
+
     }
 
     public static class PathItemContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.path_item";
+        public PathItemContextType() {
+            super("path_item", PATH_ITEM_REGEX + "$");
+        }
     }
 
     public static class SchemaContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.components.schemas";
+        public SchemaContextType() {
+            super("components.schemas", "/components/schemas");
+        }
     }
 
     public static class ParameterObjectContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.parameter_object";
+        public ParameterObjectContextType() {
+            super("parameter_object", PARAMETERS_LIST_REGEX + "/\\d+$" + "|"//
+                    + "/components/parameters/[^/]+$");
+        }
     }
 
     public static class ResponseObjectContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.responses";
+        public ResponseObjectContextType() {
+            super("responses", "/components/responses|" + //
+                    PATH_ITEM_REGEX + "/[^/]+/responses$");
+        }
     }
 
     public static class ResponseContentContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.response";
+        public ResponseContentContextType() {
+            super("response", PATH_ITEM_REGEX + "/[^/]+/responses/\\d\\d\\d");
+        }
     }
 
     public static class ComponentsObjectContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.components";
+        public ComponentsObjectContextType() {
+            super("components", "/components");
+        }
     }
 
     public static class CallbacksObjectContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.callbacks";
+        public CallbacksObjectContextType() {
+            super("callbacks", PATH_ITEM_REGEX + "/[^/]+/callbacks");
+        }
     }
 
     public static class RequestBodyObjectContextType extends OpenApi3ContextType {
-        public static final String CONTEXT_ID = "com.reprezen.swagedit.openapi3.templates.requestBody";
+        public RequestBodyObjectContextType() {
+            super("requestBody", "/requestBody");
+        }
     }
 
-    public static List<String> allContextTypes() {
-        return Lists.newArrayList( //
-                RootContextType.CONTEXT_ID, //
-                ContactContextType.CONTEXT_ID, //
-                PathsContextType.CONTEXT_ID, //
-                PathItemContextType.CONTEXT_ID, //
-                SchemaContextType.CONTEXT_ID, //
-                ParameterObjectContextType.CONTEXT_ID, //
-                ResponseObjectContextType.CONTEXT_ID, //
-                ResponseContentContextType.CONTEXT_ID, //
-                ComponentsObjectContextType.CONTEXT_ID, //
-                CallbacksObjectContextType.CONTEXT_ID, //
-                RequestBodyObjectContextType.CONTEXT_ID);
+    private static List<OpenApi3ContextType> allContextTypes = Lists.<OpenApi3ContextType> newArrayList( //
+            new RootContextType(), //
+            new ContactContextType(), //
+            new PathsContextType(), //
+            new PathItemContextType(), //
+            new SchemaContextType(), //
+            new ParameterObjectContextType(), //
+            new ResponseObjectContextType(), //
+            new ResponseContentContextType(), //
+            new ComponentsObjectContextType(), //
+            new CallbacksObjectContextType(), //
+            new RequestBodyObjectContextType());
+
+    public static List<String> allContextTypeIds() {
+        return Lists.transform(allContextTypes, new Function<OpenApi3ContextType, String>() {
+
+            @Override
+            public String apply(OpenApi3ContextType input) {
+                return input.getId();
+            }
+
+        });
     }
 
-    public static String getContextType(String path) {
-        if (path != null && path.endsWith("/")) {
-            path = path.substring(0, path.length() - 1);
+    public static OpenApi3ContextType getContextType(final String path) {
+        final String normalizedPath = (path != null && path.endsWith("/")) ? path.substring(0, path.length() - 1)
+                : path;
+        if (normalizedPath == null || normalizedPath.isEmpty() || "/".equals(normalizedPath)) {
+            return new RootContextType();
         }
-        if (path == null || path.isEmpty() || "/".equals(path)) {
-            return RootContextType.CONTEXT_ID;
-        }
-        if (path.matches("/info/contact")) {
-            return ContactContextType.CONTEXT_ID;
-        }
-        if (path.matches("/paths")) {
-            return PathsContextType.CONTEXT_ID;
-        }
-        if (path.matches(PATH_ITEM_REGEX + "$")) { // /paths/[pathItem]/
-            return PathItemContextType.CONTEXT_ID;
-        }
-        if (path.matches("/components/schemas")) {
-            return SchemaContextType.CONTEXT_ID;
-        }
-        if (path.matches(PARAMETERS_LIST_REGEX + "/\\d+$")//
-                || path.matches("/components/parameters/[^/]+$")) {
-            return ParameterObjectContextType.CONTEXT_ID;
-        }
-        if (path.equals("/components/responses")//
-                || path.matches(PATH_ITEM_REGEX + "/[^/]+/responses$")) {
-            return ResponseObjectContextType.CONTEXT_ID;
-        }
-        if (path.matches(PATH_ITEM_REGEX + "/[^/]+/responses/\\d\\d\\d")) {
-            return ResponseContentContextType.CONTEXT_ID;
-        }
-        if (path.matches(PATH_ITEM_REGEX + "/[^/]+/callbacks")) {
-            return CallbacksObjectContextType.CONTEXT_ID;
-        }
-        if (path.matches("/components")) {
-            return ComponentsObjectContextType.CONTEXT_ID;
-        }
-        if (path.matches("/components/callbacks")) {
-            return CallbacksObjectContextType.CONTEXT_ID;
-        }
-        if (path.endsWith("/requestBody")) {
-            return RequestBodyObjectContextType.CONTEXT_ID;
-        }
-        return null;
+        return Iterables.getFirst(Iterables.filter(allContextTypes, new Predicate<OpenApi3ContextType>() {
+
+            @Override
+            public boolean apply(OpenApi3ContextType input) {
+                return normalizedPath.matches(input.regex);
+            }
+
+        }), null);
     }
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/templates/OpenApi3ContextType.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/templates/OpenApi3ContextType.java
@@ -20,7 +20,7 @@ public class OpenApi3ContextType extends TemplateContextType {
     private final String regex;
 
     public OpenApi3ContextType(String name, String regex) {
-        super("com.reprezen.swagedit.openapi3.templates." + name);
+        super("com.reprezen.swagedit.openapi3.templates." + name, name);
         this.regex = regex;
         addGlobalResolvers();
     }
@@ -95,7 +95,7 @@ public class OpenApi3ContextType extends TemplateContextType {
 
     public static class CallbacksObjectContextType extends OpenApi3ContextType {
         public CallbacksObjectContextType() {
-            super("callbacks", PATH_ITEM_REGEX + "/[^/]+/callbacks");
+            super("callbacks", PATH_ITEM_REGEX + "/[^/]+/callbacks|/components/callbacks");
         }
     }
 

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/templates/OpenApi3ContextType.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/templates/OpenApi3ContextType.java
@@ -101,7 +101,7 @@ public class OpenApi3ContextType extends TemplateContextType {
 
     public static class RequestBodyObjectContextType extends OpenApi3ContextType {
         public RequestBodyObjectContextType() {
-            super("requestBody", "/requestBody");
+            super("requestBody", ".*/requestBody");
         }
     }
 


### PR DESCRIPTION
## What is being tested
I listed all reference usages in this spreadsheet:
<img width="588" alt="screen shot 2017-06-07 at 9 55 44 am" src="https://user-images.githubusercontent.com/644582/26883033-0afe99fa-4b6a-11e7-8511-8a9a01509f15.png">

Based on it, I created these JUnit tests:
<img width="526" alt="screen shot 2017-06-07 at 9 58 19 am" src="https://user-images.githubusercontent.com/644582/26883083-26c09a30-4b6a-11e7-8928-5a5a7cf6322c.png">

I found several incomplete reference contexts and fixed them.

## How tests work: convention over configuration
Test runner parses yaml models from the `com.reprezen.swagedit.openapi3.tests/resources/code-assist/references` folder. It searches for the comments with a `KZOE-ref` string, e.g.:
```yaml
      callbacks:
        myWebhook:
          #KZOE-ref name="callback in operation", value="components/callbacks"
          $ref: "#/components/callbacks/myWebhook"
```
Here, 
* `name="callback in operation"` will be used as a JUnit test name
* `value="components/callbacks"` defines how reference values should be calculated.
----------
I am also working on tests for code template contexts, so you can find some related code refactoring in this PR
