### PR TITLE
Fix type-ahead for OAS3 keywords

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/templates/SchemaBasedTemplateContextType.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/templates/SchemaBasedTemplateContextType.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.eclipse.jface.text.templates.GlobalTemplateVariables;
 import org.eclipse.jface.text.templates.TemplateContextType;
 
+import com.reprezen.swagedit.core.model.AbstractNode;
 import com.reprezen.swagedit.core.model.Model;
 import com.reprezen.swagedit.core.schema.ComplexTypeDefinition;
 import com.reprezen.swagedit.core.schema.ReferenceTypeDefinition;
@@ -33,6 +34,9 @@ public class SchemaBasedTemplateContextType extends TemplateContextType {
     }
 
     public boolean matches(Model model, final String path) {
+        if (model == null || model.find(path) == null) {
+            return false;
+        }
         TypeDefinition type = model.find(path).getType();
         return matches(type);
     }


### PR DESCRIPTION
Null `model` was causing an NPE which was propagated to `JsonContentAssistProcessor.getContextType(ITextViewer, IRegion)`. As a result, type-ahead was not working for OAS3 keywords.