### PR TITLE
[#334] OpenAPI v3: validation rule for null schema types

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/ErrorProcessor.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/ErrorProcessor.java
@@ -171,7 +171,7 @@ public class ErrorProcessor {
 
         if ("null".equals(found.asText())) {
             String pointer = ValidationUtil.getInstancePointer(error);
-            if (pointer != null && ValidationUtil.isInDefinition(pointer) && pointer.endsWith("/type")) {
+            if (pointer != null && pointer.endsWith("/type")) {
                 return Messages.error_nullType;
             }
         }

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/NullValueValidationTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/NullValueValidationTest.xtend
@@ -1,0 +1,167 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.openapi3.validation
+
+import com.reprezen.swagedit.openapi3.editor.OpenApi3Document
+import com.reprezen.swagedit.openapi3.schema.OpenApi3Schema
+import java.net.URI
+import org.junit.Test
+
+import static org.hamcrest.CoreMatchers.*
+import static org.junit.Assert.*
+
+class NullValueValidationTest {
+
+	val validator = ValidationHelper.validator()
+	val document = new OpenApi3Document(new OpenApi3Schema)
+
+	@Test
+	def void testErrorOnNullValueForType() {
+		val content = '''
+			openapi: "3.0.0"
+			info:
+			  version: 1.0.0
+			  title: some definitions
+			
+			paths: {}
+			
+			components:
+			  schemas:
+			    Phones:
+			      type: object
+			      properties:
+			        phoneId:
+			          type: null
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null as URI)
+
+		assertEquals(1, errors.size())
+		assertThat(errors.head.getMessage(),
+			containsString('The null value is not allowed for type, did you mean the "null" string (quoted)?'))
+		assertThat(errors.head.line, equalTo(11))
+	}
+
+	@Test
+	def void testOkOnNullStringForType() {
+		val content = '''
+			openapi: "3.0.0"
+			info:
+			  version: 1.0.0
+			  title: some definitions
+			
+			paths: {}
+			
+			components:
+			  schemas:
+			    Phones:
+			      type: object
+			      properties:
+			        phoneId:
+			          type: "null"
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null as URI)
+		assertEquals(0, errors.size())
+	}
+
+	@Test
+	def void testOkOnNullValueInVendorExtension() {
+		val content = '''
+			openapi: "3.0.0"
+			info:
+			  version: 1.0.0
+			  title: some definitions
+			
+			paths: {}
+			
+			components:
+			  schemas:
+			    Phones:
+			      type: object
+			      properties:
+			        phoneId:
+			          type: string
+			          x-null-prop: null
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null as URI)		
+		assertEquals(0, errors.size())
+	}
+
+	@Test
+	def void testOkOnNullValueInExample() {
+		val content = '''
+			openapi: "3.0.0"
+			info:
+			  title: Simple API overview
+			  version: v2
+			
+			paths:
+			  /myurl:
+			    get:
+			      responses:
+			        200:
+			          description: desc
+			          content:
+			            application/json:
+			              example: |-
+			                {
+			                    "nullProperty": null
+			                }
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null as URI)
+		assertEquals(0, errors.size())
+	}
+
+	@Test
+	def void testErrorOnNullValueForDescription() {
+		val content = '''
+			openapi: "3.0.0"
+			info:
+			  version: 1.0.0
+			  title: some definitions
+			
+			paths: {}
+			
+			components:
+			  schemas:
+			    Phones:
+			      type: object
+			      properties:
+			        phoneId:
+			          type: string
+			          description: null
+		'''
+
+		document.set(content)
+		document.onChange()
+
+		val errors = validator.validate(document, null as URI)
+		assertEquals(1, errors.size())
+		assertThat(errors.findFirst[true].getMessage(), containsString("value of type null is not allowed"))
+		assertThat(errors.findFirst[true].line, equalTo(11))
+	}
+
+}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidationHelper.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidationHelper.xtend
@@ -1,13 +1,17 @@
 package com.reprezen.swagedit.openapi3.validation
 
 import com.fasterxml.jackson.databind.JsonNode
+import com.google.common.collect.ImmutableMap
 import com.google.common.collect.Maps
+import com.reprezen.swagedit.core.json.references.JsonDocumentManager
 import com.reprezen.swagedit.core.json.references.JsonReferenceFactory
 import com.reprezen.swagedit.core.json.references.JsonReferenceValidator
+import com.reprezen.swagedit.core.model.AbstractNode
 import com.reprezen.swagedit.core.validation.ErrorProcessor
 import com.reprezen.swagedit.core.validation.SwaggerError
 import com.reprezen.swagedit.core.validation.Validator
 import com.reprezen.swagedit.openapi3.schema.OpenApi3Schema
+import java.net.URI
 import java.util.Map
 import java.util.Set
 
@@ -31,6 +35,36 @@ class ValidationHelper {
 
 	def protected getSchema() {
 		return new OpenApi3Schema();
+	}
+
+	def static validator() {
+		val docManager = new JsonDocumentManager() {
+			override getFile(URI uri) {
+				null
+			}
+		}
+		val factory = new JsonReferenceFactory() {
+			override create(AbstractNode node) {
+				val reference = super.create(node)
+				if (reference !== null) {
+					reference.documentManager = docManager
+				}
+				reference
+			}
+
+			override createSimpleReference(URI baseURI, AbstractNode valueNode) {
+				val reference = super.createSimpleReference(baseURI, valueNode)
+				if (reference !== null) {
+					reference.documentManager = docManager
+				}
+				reference
+			}
+		}
+
+		new OpenApi3Validator(
+			new JsonReferenceValidator(factory),
+			ImmutableMap.of("http://openapis.org/v3/schema.json", new OpenApi3Schema().asJson)
+		)
 	}
 
 }

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
@@ -1,10 +1,5 @@
 package com.reprezen.swagedit.openapi3.validation
 
-import com.google.common.collect.ImmutableMap
-import com.reprezen.swagedit.core.json.references.JsonDocumentManager
-import com.reprezen.swagedit.core.json.references.JsonReferenceFactory
-import com.reprezen.swagedit.core.json.references.JsonReferenceValidator
-import com.reprezen.swagedit.core.model.AbstractNode
 import com.reprezen.swagedit.core.validation.Messages
 import com.reprezen.swagedit.core.validation.SwaggerError
 import com.reprezen.swagedit.openapi3.editor.OpenApi3Document
@@ -18,32 +13,7 @@ import static org.junit.Assert.*
 
 class ValidatorTest {
 
-	val docManager = new JsonDocumentManager() {
-		override getFile(URI uri) {
-			null
-		}
-	}
-	val factory = new JsonReferenceFactory() {
-		override create(AbstractNode node) {
-			val reference = super.create(node)
-			if (reference !== null) {
-				reference.documentManager = docManager
-			}
-			reference
-		}
-
-		override createSimpleReference(URI baseURI, AbstractNode valueNode) {
-			val reference = super.createSimpleReference(baseURI, valueNode)
-			if (reference !== null) {
-				reference.documentManager = docManager
-			}
-			reference
-		}
-	}
-	val validator = new OpenApi3Validator(
-		new JsonReferenceValidator(factory),
-		ImmutableMap.of("http://openapis.org/v3/schema.json", new OpenApi3Schema().asJson)
-	)
+	val validator = ValidationHelper.validator()
 	val document = new OpenApi3Document(new OpenApi3Schema)
 
 	@Test
@@ -344,8 +314,10 @@ class ValidatorTest {
 		document.set(content)
 		val errors = validator.validate(document, null as URI)
 		assertEquals(1, errors.size())
-		assertThat(errors, hasItems(
-				new SwaggerError(15, IMarker.SEVERITY_ERROR, Messages.error_invalid_reference_type)		
+		assertThat(
+			errors,
+			hasItems(
+				new SwaggerError(15, IMarker.SEVERITY_ERROR, Messages.error_invalid_reference_type)
 			)
 		)
 	}
@@ -377,7 +349,7 @@ class ValidatorTest {
 		val errors = validator.validate(document, null as URI)
 		assertEquals(0, errors.size())
 	}
-	
+
 	@Test
 	def void testValidationShouldFail_SecuritySchemes() {
 		val content = '''
@@ -404,8 +376,10 @@ class ValidatorTest {
 		document.set(content)
 		val errors = validator.validate(document, null as URI)
 		assertEquals(1, errors.size())
-		assertThat(errors, hasItems(
-				new SwaggerError(10, IMarker.SEVERITY_ERROR, Messages.error_invalid_reference_type)		
+		assertThat(
+			errors,
+			hasItems(
+				new SwaggerError(10, IMarker.SEVERITY_ERROR, Messages.error_invalid_reference_type)
 			)
 		)
 	}
@@ -435,8 +409,10 @@ class ValidatorTest {
 		val errors = validator.validate(document, null as URI)
 
 		assertEquals(1, errors.size())
-		assertThat(errors, hasItems(
-				new SwaggerError(10, IMarker.SEVERITY_ERROR, Messages.error_invalid_parameter_location)		
+		assertThat(
+			errors,
+			hasItems(
+				new SwaggerError(10, IMarker.SEVERITY_ERROR, Messages.error_invalid_parameter_location)
 			)
 		)
 	}
@@ -465,6 +441,6 @@ class ValidatorTest {
 		document.set(content)
 		val errors = validator.validate(document, null as URI)
 
-		assertEquals(0, errors.size())		
+		assertEquals(0, errors.size())
 	}
 }


### PR DESCRIPTION
I made a little change in the ErrorValidator to allow it to work on OpenApi3. The only remaining issue would be that the marker is not placed where is the `null` value, but on the container object. See:

![screen shot 2017-09-22 at 14 24 22](https://user-images.githubusercontent.com/148045/30750040-a1d34778-9fb5-11e7-8e68-b21b21ec6eb4.png)


![screen shot 2017-09-22 at 14 24 25](https://user-images.githubusercontent.com/148045/30750050-a77702dc-9fb5-11e7-9f57-8b15c919336a.png)
