### PR TITLE
#394: Template "Schema with a Required Property" inserts at the wrong indent level

### DIFF
--- a/com.reprezen.swagedit.openapi3/resources/templates.xml
+++ b/com.reprezen.swagedit.openapi3/resources/templates.xml
@@ -305,7 +305,7 @@ content:
        description="Schema definition with a required property" 
        context="com.reprezen.swagedit.openapi3.templates.schema" 
        enabled="true">required:
-  - ${property}
+- ${property}
 properties:
   ${property}:
     type: integer

--- a/com.reprezen.swagedit.openapi3/resources/templates.xml
+++ b/com.reprezen.swagedit.openapi3/resources/templates.xml
@@ -280,13 +280,13 @@ content:
        description="Schema definition with a required property" 
        context="com.reprezen.swagedit.openapi3.templates.schemas" 
        enabled="true">${type}:
-required:
-  - ${property}
-properties:
-  ${property}:
-    type: integer
-    format: int64</template>
-
+  required:
+    - ${property}
+  properties:
+    ${property}:
+      type: integer
+      format: int64</template>
+      
 <!--
 	SCHEMA OBJECT
  -->


### PR DESCRIPTION
PR # 387 modified a wrong template, and
* did not fix the original problem
* introduced a new bug with a *named* schema template

This PR fixes both.