### PR TITLE
[#335] Navigation to Operation#securityScheme, Link#operationId, and …

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/hyperlinks/JsonReferenceHyperlinkDetector.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/hyperlinks/JsonReferenceHyperlinkDetector.java
@@ -37,7 +37,7 @@ public abstract class JsonReferenceHyperlinkDetector extends AbstractJsonHyperli
 
     @Override
     protected boolean canDetect(JsonPointer pointer) {
-        return pointer != null && pointer.toString().endsWith("$ref");
+        return pointer != null && (pointer.toString().endsWith("$ref") || pointer.toString().endsWith("operationRef"));
     }
 
     @Override

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/hyperlinks/JsonReferenceHyperlinkDetector.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/hyperlinks/JsonReferenceHyperlinkDetector.java
@@ -10,86 +10,25 @@
  *******************************************************************************/
 package com.reprezen.swagedit.core.hyperlinks;
 
-import java.net.URI;
-
 import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.IRegion;
-import org.eclipse.jface.text.ITextViewer;
-import org.eclipse.jface.text.hyperlink.IHyperlink;
-import org.eclipse.ui.part.FileEditorInput;
 
 import com.fasterxml.jackson.core.JsonPointer;
-import com.reprezen.swagedit.core.editor.JsonDocument;
-import com.reprezen.swagedit.core.json.references.JsonReference;
-import com.reprezen.swagedit.core.json.references.JsonReferenceFactory;
-import com.reprezen.swagedit.core.model.AbstractNode;
-import com.reprezen.swagedit.core.utils.DocumentUtils;
 
 /**
  * Hyperlink detector that detects links from JSON references.
- * 
  */
-public abstract class JsonReferenceHyperlinkDetector extends AbstractJsonHyperlinkDetector {
-
-    protected final JsonReferenceFactory factory = new JsonReferenceFactory();
-    
-    protected abstract JsonFileHyperlink createFileHyperlink(IRegion linkRegion, String label, IFile file, JsonPointer pointer) ;
+public abstract class JsonReferenceHyperlinkDetector extends ReferenceHyperlinkDetector {
 
     @Override
-    protected boolean canDetect(JsonPointer pointer) {
-        return pointer != null && (pointer.toString().endsWith("$ref") || pointer.toString().endsWith("operationRef"));
-    }
-
-    @Override
-    protected IHyperlink[] doDetect(JsonDocument doc, ITextViewer viewer, HyperlinkInfo info, JsonPointer pointer) {
-        URI baseURI = getBaseURI();
-
-        AbstractNode node = doc.getModel().find(pointer);
-        JsonReference reference = getFactory().createSimpleReference(getBaseURI(), node);
-        if (reference == null) {
-            reference = getFactory().create(node);
-        }
-
-        if (reference.isInvalid() || reference.isMissing(doc, getBaseURI())) {
-            return null;
-        }
-
-        if (reference.isLocal()) {
-            IRegion target = doc.getRegion(reference.getPointer());
-            if (target == null) {
-                return null;
-            }
-            return new IHyperlink[] { new SwaggerHyperlink(reference.getPointer().toString(), viewer, info.region,
-                    target) };
-        } else {
-            URI resolved;
-            try {
-                resolved = baseURI.resolve(reference.getUri());
-            } catch (IllegalArgumentException e) {
-                // the given string violates RFC 2396
-                return null;
-            }
-            IFile file = DocumentUtils.getWorkspaceFile(resolved);
-			if (file != null && file.exists()) {
-				return new IHyperlink[] { createFileHyperlink(info.region, info.text, file, reference.getPointer()) };
-			}
-        }
-
+    protected JsonFileHyperlink createFileHyperlink(IRegion linkRegion, String label, IFile file, JsonPointer pointer) {
+        // TODO Auto-generated method stub
         return null;
     }
 
-    protected FileEditorInput getActiveEditor() {
-        return DocumentUtils.getActiveEditorInput();
-    }
-
-    protected URI getBaseURI() {
-        FileEditorInput editor = getActiveEditor();
-
-        return editor != null ? editor.getURI() : null;
-    }
-
-    protected JsonReferenceFactory getFactory() {
-        return factory;
+    @Override
+    protected boolean canDetect(JsonPointer pointer) {
+        return pointer != null && pointer.toString().endsWith("$ref");
     }
 
 }

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/hyperlinks/ReferenceHyperlinkDetector.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/hyperlinks/ReferenceHyperlinkDetector.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.core.hyperlinks;
+
+import java.net.URI;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+import org.eclipse.ui.part.FileEditorInput;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.reprezen.swagedit.core.editor.JsonDocument;
+import com.reprezen.swagedit.core.json.references.JsonReference;
+import com.reprezen.swagedit.core.json.references.JsonReferenceFactory;
+import com.reprezen.swagedit.core.model.AbstractNode;
+import com.reprezen.swagedit.core.utils.DocumentUtils;
+
+public abstract class ReferenceHyperlinkDetector extends AbstractJsonHyperlinkDetector {
+
+    protected final JsonReferenceFactory factory = new JsonReferenceFactory();
+
+    protected abstract JsonFileHyperlink createFileHyperlink(IRegion linkRegion, String label, IFile file,
+            JsonPointer pointer);
+
+    @Override
+    protected abstract boolean canDetect(JsonPointer pointer);
+
+    @Override
+    protected IHyperlink[] doDetect(JsonDocument doc, ITextViewer viewer, HyperlinkInfo info, JsonPointer pointer) {
+        URI baseURI = getBaseURI();
+
+        AbstractNode node = doc.getModel().find(pointer);
+        JsonReference reference = getFactory().createSimpleReference(getBaseURI(), node);
+        if (reference == null) {
+            reference = getFactory().create(node);
+        }
+
+        if (reference.isInvalid() || reference.isMissing(doc, getBaseURI())) {
+            return null;
+        }
+
+        if (reference.isLocal()) {
+            IRegion target = doc.getRegion(reference.getPointer());
+            if (target == null) {
+                return null;
+            }
+            return new IHyperlink[] {
+                    new SwaggerHyperlink(reference.getPointer().toString(), viewer, info.region, target) };
+        } else {
+            URI resolved;
+            try {
+                resolved = baseURI.resolve(reference.getUri());
+            } catch (IllegalArgumentException e) {
+                // the given string violates RFC 2396
+                return null;
+            }
+            IFile file = DocumentUtils.getWorkspaceFile(resolved);
+            if (file != null && file.exists()) {
+                return new IHyperlink[] { createFileHyperlink(info.region, info.text, file, reference.getPointer()) };
+            }
+        }
+
+        return null;
+    }
+
+    protected FileEditorInput getActiveEditor() {
+        return DocumentUtils.getActiveEditorInput();
+    }
+
+    protected URI getBaseURI() {
+        FileEditorInput editor = getActiveEditor();
+
+        return editor != null ? editor.getURI() : null;
+    }
+
+    protected JsonReferenceFactory getFactory() {
+        return factory;
+    }
+
+}

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/hyperlinks/SwaggerHyperlink.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/hyperlinks/SwaggerHyperlink.java
@@ -43,6 +43,10 @@ public class SwaggerHyperlink implements IHyperlink {
         return text;
     }
 
+    public IRegion getTarget() {
+        return target;
+    }
+
     @Override
     public void open() {
         if (viewer != null) {

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceFactory.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceFactory.java
@@ -114,6 +114,11 @@ public class JsonReferenceFactory {
         String fragment = uri.getFragment();
         JsonPointer pointer = null;
         try {
+            // Pointer fails to resolve if ends with /
+            if (fragment.endsWith("/")) {
+                fragment = fragment.substring(0, fragment.length() - 1);
+            }
+
             pointer = JsonPointer.compile(Strings.emptyToNull(fragment));
         } catch (IllegalArgumentException e) {
             // let the pointer be null

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceFactory.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceFactory.java
@@ -115,7 +115,7 @@ public class JsonReferenceFactory {
         JsonPointer pointer = null;
         try {
             // Pointer fails to resolve if ends with /
-            if (fragment.endsWith("/")) {
+            if (fragment != null && fragment.length() > 1 && fragment.endsWith("/")) {
                 fragment = fragment.substring(0, fragment.length() - 1);
             }
 

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessorTest.xtend
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.assist
 
 import com.reprezen.swagedit.core.assist.StyledCompletionProposal

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/editor/hyperlinks/HyperlinkDetectorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/editor/hyperlinks/HyperlinkDetectorTest.xtend
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.editor.hyperlinks
 
 import com.reprezen.swagedit.openapi3.editor.OpenApi3Document
@@ -10,14 +20,20 @@ import org.junit.Test
 import static org.junit.Assert.*
 import com.reprezen.swagedit.core.hyperlinks.SwaggerHyperlink
 import com.reprezen.swagedit.openapi3.hyperlinks.LinkOperationHyperlinkDetector
+import com.reprezen.swagedit.openapi3.hyperlinks.LinkOperationRefHyperlinkDetector
 
 class HyperlinkDetectorTest {
 
 	val securityDetector = new SecuritySchemeHyperlinkDetector
 	val operationDetector = new LinkOperationHyperlinkDetector
+	val operationRefDetector = new LinkOperationRefHyperlinkDetector() {
+		override protected getActiveEditor() {
+			null
+		}	
+	}
 
 	@Test
-	def void testShouldCreateHyperLink_FromSecuirtyRequirement() throws Exception {
+	def void testShouldCreateHyperLink_FromSecurityRequirement() throws Exception {
 		val document = new OpenApi3Document(new OpenApi3Schema)
 		val viewer = Mocks.mockTextViewer(document)
 
@@ -67,6 +83,38 @@ class HyperlinkDetectorTest {
 
 		val region = groups.get("1")
 		val hyperlinks = operationDetector.detectHyperlinks(viewer, region, false)
+
+		assertNotNull(hyperlinks);
+		assertEquals(1, hyperlinks.size)
+
+		val link = hyperlinks.get(0)
+		val target = (link as SwaggerHyperlink).target
+
+		// target on same line
+		assertEquals(
+			document.getLineOfOffset(groups.get("2").offset),
+			document.getLineOfOffset(target.offset)
+		)
+	}
+
+	@Test
+	def void testShouldCreateHyperLink_FromOperationRef() throws Exception {
+		val document = new OpenApi3Document(new OpenApi3Schema)
+		val viewer = Mocks.mockTextViewer(document)
+
+		val groups = Cursors.setUpRegions('''
+			paths:
+			  /:
+			    <2>get:
+			      operationId: list
+			components:
+			  links:
+			    foo:
+			      operationRef: '#/<1>paths/~1/get'
+		''', document)
+
+		val region = groups.get("1")
+		val hyperlinks = operationRefDetector.detectHyperlinks(viewer, region, false)
 
 		assertNotNull(hyperlinks);
 		assertEquals(1, hyperlinks.size)

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/editor/hyperlinks/HyperlinkDetectorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/editor/hyperlinks/HyperlinkDetectorTest.xtend
@@ -1,0 +1,83 @@
+package com.reprezen.swagedit.openapi3.editor.hyperlinks
+
+import com.reprezen.swagedit.openapi3.editor.OpenApi3Document
+import com.reprezen.swagedit.openapi3.hyperlinks.SecuritySchemeHyperlinkDetector
+import com.reprezen.swagedit.openapi3.schema.OpenApi3Schema
+import com.reprezen.swagedit.openapi3.utils.Cursors
+import com.reprezen.swagedit.openapi3.utils.Mocks
+import org.junit.Test
+
+import static org.junit.Assert.*
+import com.reprezen.swagedit.core.hyperlinks.SwaggerHyperlink
+import com.reprezen.swagedit.openapi3.hyperlinks.LinkOperationHyperlinkDetector
+
+class HyperlinkDetectorTest {
+
+	val securityDetector = new SecuritySchemeHyperlinkDetector
+	val operationDetector = new LinkOperationHyperlinkDetector
+
+	@Test
+	def void testShouldCreateHyperLink_FromSecuirtyRequirement() throws Exception {
+		val document = new OpenApi3Document(new OpenApi3Schema)
+		val viewer = Mocks.mockTextViewer(document)
+
+		val groups = Cursors.setUpRegions('''
+			paths:
+			  /:
+			    get:
+			      security:
+			        - bas<1>ic: []
+			components:
+			  securitySchemes:
+			    <2>basic:
+			      type: http
+		''', document)
+
+		val region = groups.get("1")
+		val hyperlinks = securityDetector.detectHyperlinks(viewer, region, false)
+
+		assertNotNull(hyperlinks);
+		assertEquals(1, hyperlinks.size)
+
+		val link = hyperlinks.get(0)
+		val target = (link as SwaggerHyperlink).target
+
+		// target on same line
+		assertEquals(
+			document.getLineOfOffset(groups.get("2").offset),
+			document.getLineOfOffset(target.offset)
+		)
+	}
+
+	@Test
+	def void testShouldCreateHyperLink_FromOperationId() throws Exception {
+		val document = new OpenApi3Document(new OpenApi3Schema)
+		val viewer = Mocks.mockTextViewer(document)
+
+		val groups = Cursors.setUpRegions('''
+			paths:
+			  /:
+			    get:
+			      <2>operationId: list
+			components:
+			  links:
+			    foo:
+			      operationId: li<1>st
+		''', document)
+
+		val region = groups.get("1")
+		val hyperlinks = operationDetector.detectHyperlinks(viewer, region, false)
+
+		assertNotNull(hyperlinks);
+		assertEquals(1, hyperlinks.size)
+
+		val link = hyperlinks.get(0)
+		val target = (link as SwaggerHyperlink).target
+
+		// target on same line
+		assertEquals(
+			document.getLineOfOffset(groups.get("2").offset),
+			document.getLineOfOffset(target.offset)
+		)
+	}
+}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/editor/hyperlinks/HyperlinkDetectorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/editor/hyperlinks/HyperlinkDetectorTest.xtend
@@ -29,7 +29,7 @@ class HyperlinkDetectorTest {
 	val operationRefDetector = new LinkOperationRefHyperlinkDetector() {
 		override protected getActiveEditor() {
 			null
-		}	
+		}
 	}
 
 	@Test
@@ -111,6 +111,72 @@ class HyperlinkDetectorTest {
 			  links:
 			    foo:
 			      operationRef: '#/<1>paths/~1/get'
+		''', document)
+
+		val region = groups.get("1")
+		val hyperlinks = operationRefDetector.detectHyperlinks(viewer, region, false)
+
+		assertNotNull(hyperlinks);
+		assertEquals(1, hyperlinks.size)
+
+		val link = hyperlinks.get(0)
+		val target = (link as SwaggerHyperlink).target
+
+		// target on same line
+		assertEquals(
+			document.getLineOfOffset(groups.get("2").offset),
+			document.getLineOfOffset(target.offset)
+		)
+	}
+
+	@Test
+	def void testShouldCreateHyperLink_FromLinkInsideResponses() throws Exception {
+		val document = new OpenApi3Document(new OpenApi3Schema)
+		val viewer = Mocks.mockTextViewer(document)
+
+		val groups = Cursors.setUpRegions('''
+			paths:
+			  /:
+			    get:
+			      <2>operationId: list
+			      responses:
+			        '200':
+			          links:
+			            foo:
+			              operationId: li<1>st
+		''', document)
+
+		val region = groups.get("1")
+		val hyperlinks = operationDetector.detectHyperlinks(viewer, region, false)
+
+		assertNotNull(hyperlinks);
+		assertEquals(1, hyperlinks.size)
+
+		val link = hyperlinks.get(0)
+		val target = (link as SwaggerHyperlink).target
+
+		// target on same line
+		assertEquals(
+			document.getLineOfOffset(groups.get("2").offset),
+			document.getLineOfOffset(target.offset)
+		)
+	}
+
+	@Test
+	def void testShouldCreateHyperLink_FromLinkOperationRefInsideResponses() throws Exception {
+		val document = new OpenApi3Document(new OpenApi3Schema)
+		val viewer = Mocks.mockTextViewer(document)
+
+		val groups = Cursors.setUpRegions('''
+			paths:
+			  /:
+			    <2>get:
+			      operationId: list
+			      responses:
+			        '200':
+			          links:
+			            foo:
+			              operationRef: '#/<1>paths/~1/get'
 		''', document)
 
 		val region = groups.get("1")

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/schema/SchemaValidationTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/schema/SchemaValidationTest.xtend
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.schema
 
 import com.fasterxml.jackson.databind.ObjectMapper

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Cursors.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Cursors.xtend
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.utils
 
 import com.fasterxml.jackson.core.JsonPointer

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Cursors.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Cursors.xtend
@@ -12,8 +12,17 @@ import org.eclipse.xtext.xbase.lib.Functions.Function2
 import org.eclipse.xtext.xbase.lib.Procedures.Procedure2
 
 import static org.junit.Assert.*
+import java.util.Map
 
 class Cursors {
+
+	static def Map<String, IRegion> setUpRegions(String yaml, OpenApi3Document doc) {
+		val groups = groupMarkers(yaml)
+		doc.set(removeMarkers(yaml))
+		doc.onChange
+
+		groups
+	}
 
 	static def (String, String)=>void setUpPathTest(String yaml, OpenApi3Document doc) {
 		val groups = groupMarkers(yaml)

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Mocks.java
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Mocks.java
@@ -12,6 +12,12 @@ import com.reprezen.swagedit.openapi3.editor.OpenApi3Document;
 
 public class Mocks {
 
+    public static ITextViewer mockTextViewer(OpenApi3Document document) {
+        ITextViewer viewer = mock(ITextViewer.class);
+        when(viewer.getDocument()).thenReturn(document);
+        return viewer;
+    }
+
     public static ITextViewer mockTextViewer(OpenApi3Document document, int offset) {
         ITextViewer viewer = mock(ITextViewer.class);
         ISelectionProvider selectionProvider = mockSelectionProvider();

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Mocks.java
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Mocks.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.utils;
 
 import static org.mockito.Mockito.mock;

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.validation
 
 import com.fasterxml.jackson.databind.JsonNode

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidationHelper.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidationHelper.xtend
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.validation
 
 import com.fasterxml.jackson.databind.JsonNode

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.validation
 
 import com.reprezen.swagedit.core.validation.Messages

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/Activator.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/Activator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3;
 
 import java.io.IOException;

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/contexts/OperationContextType.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/contexts/OperationContextType.java
@@ -32,7 +32,7 @@ public class OperationContextType extends SchemaContextType {
 
         for (AbstractNode node : nodes) {
             String pointer = node.getPointerString();
-            String basePath = (path != null ? path.toString() : "") + "#" + pointer + "/";
+            String basePath = (path != null ? path.toString() : "") + "#" + pointer;
             String key = node.getProperty();
             String value = basePath;
             String encoded = URLUtils.encodeURL(value);

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/contexts/OperationContextType.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/contexts/OperationContextType.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.assist.contexts;
 
 import java.util.Collection;

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/contexts/OperationIdContextType.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/contexts/OperationIdContextType.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.assist.contexts;
 
 import java.util.Collection;

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/contexts/SecuritySchemeContextType.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/assist/contexts/SecuritySchemeContextType.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.assist.contexts;
 
 import java.util.Collection;

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.editor;
 
 import java.util.Map;
@@ -23,6 +33,7 @@ import com.reprezen.swagedit.core.validation.Validator;
 import com.reprezen.swagedit.openapi3.Activator;
 import com.reprezen.swagedit.openapi3.assist.OpenApi3ContentAssistProcessor;
 import com.reprezen.swagedit.openapi3.hyperlinks.LinkOperationHyperlinkDetector;
+import com.reprezen.swagedit.openapi3.hyperlinks.LinkOperationRefHyperlinkDetector;
 import com.reprezen.swagedit.openapi3.hyperlinks.OpenApi3ReferenceHyperlinkDetector;
 import com.reprezen.swagedit.openapi3.hyperlinks.SecuritySchemeHyperlinkDetector;
 import com.reprezen.swagedit.openapi3.validation.OpenApi3Validator;
@@ -60,7 +71,8 @@ public class OpenApi3Editor extends JsonEditor {
                     new DefinitionHyperlinkDetector(), //
                     new OpenApi3ReferenceHyperlinkDetector(), //
                     new SecuritySchemeHyperlinkDetector(), //
-                    new LinkOperationHyperlinkDetector() };
+                    new LinkOperationHyperlinkDetector(), //
+                    new LinkOperationRefHyperlinkDetector() };
 		}
 
 		@Override

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
@@ -22,7 +22,9 @@ import com.reprezen.swagedit.core.schema.CompositeSchema;
 import com.reprezen.swagedit.core.validation.Validator;
 import com.reprezen.swagedit.openapi3.Activator;
 import com.reprezen.swagedit.openapi3.assist.OpenApi3ContentAssistProcessor;
+import com.reprezen.swagedit.openapi3.hyperlinks.LinkOperationHyperlinkDetector;
 import com.reprezen.swagedit.openapi3.hyperlinks.OpenApi3ReferenceHyperlinkDetector;
+import com.reprezen.swagedit.openapi3.hyperlinks.SecuritySchemeHyperlinkDetector;
 import com.reprezen.swagedit.openapi3.validation.OpenApi3Validator;
 
 public class OpenApi3Editor extends JsonEditor {
@@ -56,7 +58,9 @@ public class OpenApi3Editor extends JsonEditor {
             return new IHyperlinkDetector[] { new URLHyperlinkDetector(), //
                     new PathParamHyperlinkDetector(), //
                     new DefinitionHyperlinkDetector(), //
-                    new OpenApi3ReferenceHyperlinkDetector() };
+                    new OpenApi3ReferenceHyperlinkDetector(), //
+                    new SecuritySchemeHyperlinkDetector(), //
+                    new LinkOperationHyperlinkDetector() };
 		}
 
 		@Override

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/LinkOperationHyperlinkDetector.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/LinkOperationHyperlinkDetector.java
@@ -1,0 +1,52 @@
+package com.reprezen.swagedit.openapi3.hyperlinks;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Objects;
+
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.reprezen.swagedit.core.editor.JsonDocument;
+import com.reprezen.swagedit.core.hyperlinks.AbstractJsonHyperlinkDetector;
+import com.reprezen.swagedit.core.hyperlinks.SwaggerHyperlink;
+import com.reprezen.swagedit.core.model.AbstractNode;
+import com.reprezen.swagedit.core.model.Model;
+
+public class LinkOperationHyperlinkDetector extends AbstractJsonHyperlinkDetector {
+
+    @Override
+    protected boolean canDetect(JsonPointer pointer) {
+        return pointer != null && pointer.toString().matches("/components/links/(\\w+)/operationId");
+    }
+
+    @Override
+    protected IHyperlink[] doDetect(JsonDocument doc, ITextViewer viewer, HyperlinkInfo info, JsonPointer pointer) {
+        Model model = doc.getModel();
+        AbstractNode node = model.find(pointer);
+        List<AbstractNode> nodes = model.findByType(JsonPointer.compile("/definitions/operation"));
+        Iterator<AbstractNode> it = nodes.iterator();
+
+        AbstractNode found = null;
+        while (it.hasNext() && found == null) {
+            AbstractNode current = it.next();
+            AbstractNode value = current.get("operationId");
+
+            if (value != null && Objects.equals(node.asValue().getValue(), value.asValue().getValue())) {
+                found = value;
+            }
+        }
+
+        if (found != null) {
+            IRegion target = doc.getRegion(found.getPointer());
+            if (target != null) {
+                return new IHyperlink[] { new SwaggerHyperlink(info.text, viewer, info.region, target) };
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/LinkOperationHyperlinkDetector.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/LinkOperationHyperlinkDetector.java
@@ -29,7 +29,7 @@ public class LinkOperationHyperlinkDetector extends AbstractJsonHyperlinkDetecto
 
     @Override
     protected boolean canDetect(JsonPointer pointer) {
-        return pointer != null && pointer.toString().matches("/components/links/(\\w+)/operationId");
+        return pointer != null && pointer.toString().matches(".*/links/(\\w+)/operationId");
     }
 
     @Override

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/LinkOperationHyperlinkDetector.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/LinkOperationHyperlinkDetector.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.hyperlinks;
 
 import java.util.Iterator;

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/LinkOperationRefHyperlinkDetector.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/LinkOperationRefHyperlinkDetector.java
@@ -15,13 +15,18 @@ import org.eclipse.jface.text.IRegion;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.reprezen.swagedit.core.hyperlinks.JsonFileHyperlink;
-import com.reprezen.swagedit.core.hyperlinks.JsonReferenceHyperlinkDetector;
+import com.reprezen.swagedit.core.hyperlinks.ReferenceHyperlinkDetector;
 
-public class OpenApi3ReferenceHyperlinkDetector extends JsonReferenceHyperlinkDetector {
+public class LinkOperationRefHyperlinkDetector extends ReferenceHyperlinkDetector {
 
-	@Override
-	protected JsonFileHyperlink createFileHyperlink(IRegion linkRegion, String label, IFile file, JsonPointer pointer) {
-		return new OpenApi3FileHyperlink(linkRegion, label, file, pointer);
-	}
+    @Override
+    protected JsonFileHyperlink createFileHyperlink(IRegion linkRegion, String label, IFile file, JsonPointer pointer) {
+        return new OpenApi3FileHyperlink(linkRegion, label, file, pointer);
+    }
+
+    @Override
+    protected boolean canDetect(JsonPointer pointer) {
+        return pointer != null && pointer.toString().endsWith("operationRef");
+    }
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/OpenApi3FileHyperlink.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/OpenApi3FileHyperlink.java
@@ -14,14 +14,19 @@ import org.eclipse.core.resources.IFile;
 import org.eclipse.jface.text.IRegion;
 
 import com.fasterxml.jackson.core.JsonPointer;
+import com.reprezen.swagedit.core.editor.JsonDocument;
 import com.reprezen.swagedit.core.hyperlinks.JsonFileHyperlink;
-import com.reprezen.swagedit.core.hyperlinks.JsonReferenceHyperlinkDetector;
+import com.reprezen.swagedit.openapi3.editor.OpenApi3Document;
 
-public class OpenApi3ReferenceHyperlinkDetector extends JsonReferenceHyperlinkDetector {
+public class OpenApi3FileHyperlink extends JsonFileHyperlink {
 
-	@Override
-	protected JsonFileHyperlink createFileHyperlink(IRegion linkRegion, String label, IFile file, JsonPointer pointer) {
-		return new OpenApi3FileHyperlink(linkRegion, label, file, pointer);
+	public OpenApi3FileHyperlink(IRegion linkRegion, String label, IFile file, JsonPointer pointer) {
+		super(linkRegion, label, file, pointer);
 	}
 
+	@Override
+	protected JsonDocument createDocument() {
+		return new OpenApi3Document();
+	}
+	
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/SecuritySchemeHyperlinkDetector.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/SecuritySchemeHyperlinkDetector.java
@@ -1,0 +1,46 @@
+package com.reprezen.swagedit.openapi3.hyperlinks;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.ITextViewer;
+import org.eclipse.jface.text.hyperlink.IHyperlink;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.reprezen.swagedit.core.editor.JsonDocument;
+import com.reprezen.swagedit.core.hyperlinks.AbstractJsonHyperlinkDetector;
+import com.reprezen.swagedit.core.hyperlinks.SwaggerHyperlink;
+import com.reprezen.swagedit.core.model.AbstractNode;
+import com.reprezen.swagedit.core.model.Model;
+
+public class SecuritySchemeHyperlinkDetector extends AbstractJsonHyperlinkDetector {
+
+    protected static final String REGEX = ".*/security/\\d+/(\\w+)";
+    protected static final Pattern PATTERN = Pattern.compile(REGEX);
+
+    @Override
+    protected boolean canDetect(JsonPointer pointer) {
+        return pointer != null && pointer.toString().matches(REGEX);
+    }
+
+    @Override
+    protected IHyperlink[] doDetect(JsonDocument doc, ITextViewer viewer, HyperlinkInfo info, JsonPointer pointer) {
+        Matcher matcher = PATTERN.matcher(pointer.toString());
+        String link = matcher.find() ? matcher.group(1) : null;
+
+        if (link != null) {
+            Model model = doc.getModel();
+            AbstractNode securityScheme = model.find("/components/securitySchemes/" + link);
+
+            if (securityScheme != null) {
+                IRegion target = doc.getRegion(securityScheme.getPointer());
+                if (target != null) {
+                    return new IHyperlink[] { new SwaggerHyperlink(info.text, viewer, info.region, target) };
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/SecuritySchemeHyperlinkDetector.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/hyperlinks/SecuritySchemeHyperlinkDetector.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.hyperlinks;
 
 import java.util.regex.Matcher;

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/schema/OpenApi3Schema.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/schema/OpenApi3Schema.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.schema;
 
 import java.io.IOException;

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3Validator.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3Validator.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ *  Copyright (c) 2016 ModelSolv, Inc. and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Public License v1.0
+ *  which accompanies this distribution, and is available at
+ *  http://www.eclipse.org/legal/epl-v10.html
+ *  
+ *  Contributors:
+ *     ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
 package com.reprezen.swagedit.openapi3.validation;
 
 import java.util.Iterator;


### PR DESCRIPTION
…Link#operationRef

See #335 

Added new hyperlink detectors for security schemes and link operationId. For link operationRef, I modified the existing JsonReferenceDetector to work not only on $ref but also on operationRef. 
Added tests for security schemes and link operationId detectors.