### PR TITLE
[#308] OpenAPI v3: Validation for the value of Link#operationId

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/Messages.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/Messages.java
@@ -42,6 +42,7 @@ public class Messages extends NLS {
     public static String error_scope_should_be_empty;
     public static String error_scope_should_not_be_empty;
     public static String error_invalid_scope_reference;
+    public static String error_invalid_operation_id;
 
     public static String error_array_missing_items;
     public static String error_object_type_missing;

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/messages.properties
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/messages.properties
@@ -34,7 +34,7 @@ error_wrong_type = Invalid type, should be object
 error_missing_properties = Invalid type definition, object has a required field but is missing a properties field
 warning_simple_reference = Simplified reference syntax is deprecated. The reference should be a valid JSON pointer.
 error_array_missing_items= Invalid array definition, items type should be present
-error_invalid_reference_type = Invalid object reference, the referenced object is not of expected type.
+error_invalid_reference_type = Invalid object reference, the referenced object is not of expected type.   
 error_invalid_parameter_location = Invalid parameter location value, possible values are \"query\", \"header\", \"path\" or \"cookie\".
 content_assist_proposal_local = Press '%s' to show %s in the current file.
 content_assist_proposal_project = Press '%s' to show all %s in the project.
@@ -48,7 +48,8 @@ Example: "%s : []"
 error_scope_should_not_be_empty = %s is defined as an %s-typed security scheme. \n\
 Security requirements for oauth or openIdConnect schemes must specify a list of scope names required for execution.
 error_invalid_scope_reference = "%s" does not match any scope name defined in the %s security scheme. 
-
+error_invalid_operation_id = Invalid operationId. \n\
+This operationId does not match any existing and resolvable operation.
 
 # yaml
 error_yaml_parser_indentation = Unable to parse content, an incorrect indentation may be the cause.

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
@@ -273,6 +273,7 @@ class ValidatorTest {
 		document.set(content)
 		val errors = validator.validate(document, null as URI)
 		assertEquals(1, errors.size())
+		assertTrue(errors.map[message].forall[it.equals(Messages.error_invalid_operation_id)])
 	}
 
 	@Test

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3Validator.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3Validator.java
@@ -168,7 +168,7 @@ public class OpenApi3Validator extends Validator {
             }
 
             if (!found) {
-                errors.add(error(node, IMarker.SEVERITY_ERROR, Messages.error_invalid_reference_type));
+                errors.add(error(node, IMarker.SEVERITY_ERROR, Messages.error_invalid_operation_id));
             }
         }
     }


### PR DESCRIPTION
See #308 

The error message is now ` Invalid operationId. This operationId does not match any existing and resolvable operation.`