### PR TITLE
[#410] References to path items are not treated correctly

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/Model.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/Model.java
@@ -15,6 +15,8 @@ import static com.reprezen.swagedit.core.model.NodeDeserializer.ATTRIBUTE_PARENT
 import static com.reprezen.swagedit.core.model.NodeDeserializer.ATTRIBUTE_POINTER;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -221,6 +223,12 @@ public class Model {
         }
         if (pointer.length() > 1 && pointer.endsWith("/")) {
             pointer = pointer.substring(0, pointer.length() - 1);
+        }
+
+        try {
+            pointer = URLDecoder.decode(pointer, "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            // leave the pointer as it is
         }
 
         try {

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
@@ -136,15 +136,20 @@ class ReferenceValidatorTest {
 			  /foo/{bar}:
 			    get:
 			      parameters:
-			        - $ref: '#/paths/~1foo~1%7Bbar%7D'
+			        - $ref: '#/components/parameters/bar'
 			      responses:
 			        '200':
 			          description: OK
+			components:
+			  parameters:
+			    bar:
+			      name: bar
+			      in: path
 		'''
 
 		document.set(content)
 		val baseURI = new URI(null, null, null)
-		val resolvedURI = new URI(null, null, "/paths/~1foo~1{bar}")
+		val resolvedURI = new URI(null, null, "/components/parameters/bar")
 		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
 
 		assertEquals(0, errors.size())

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
@@ -695,6 +695,32 @@ class ValidatorTest {
 		assertThat(errors.map[line], hasItems(9))
 	}
 
+	@Test
+	def void testPointerWithSpecialCharacters() {
+		val content = '''		
+		openapi: "3.0.0"
+		info:
+		  version: "1.0.0"
+		  title: Test API
+		paths:
+		  /test/{id}:
+		    get:
+		      responses:
+		        '200':
+		          description: OK
+		          content:
+		            application/json:
+		              schema:
+		                $ref: "#/paths/~1test~1%7Bid%7D"
+		'''
+		
+		document.set(content)
+		val errors = validator.validate(document, null as URI)
+		assertEquals(1, errors.size())
+		assertTrue(errors.map[message].forall[it.equals(Messages.error_invalid_reference_type)])
+		assertThat(errors.map[line], hasItems(14))
+	}
+
 	private def shouldHaveInvalidReferenceType(String actual) {
 		expectedMessage(Messages.error_invalid_reference_type + " It should be a valid security scheme.").apply(actual)
 	}

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
@@ -122,15 +122,19 @@ class ReferenceValidatorTest {
 			  /foo/{bar}:
 			    get:
 			      parameters:
-			        - $ref: '#/paths/~1foo~1%7Bbar%7D'
+			        - $ref: '#/parameters/bar'
 			      responses:
 			        '200':
 			          description: OK
+			parameters:
+			  bar:
+			    name: bar
+			    in: path
 		'''
 
 		document.set(content)
 		val baseURI = new URI(null, null, null)
-		val resolvedURI = new URI(null, null, "/paths/~1foo~1{bar}")
+		val resolvedURI = new URI(null, null, "/parameters/bar")
 		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
 
 		assertEquals(0, errors.size())


### PR DESCRIPTION
See #410 

Model.find method now decodes pointers to handle special characters such as { and }.