### PR TITLE
[#306] OpenAPI v3: Validation for Link#operationRef values

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceCollector.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceCollector.java
@@ -44,7 +44,7 @@ public class JsonReferenceCollector {
         final Map<AbstractNode, JsonReference> references = Maps.newHashMap();
 
         for (AbstractNode node : model.allNodes()) {
-            if (JsonReference.isReference(node)) {
+            if (factory.isReference(node)) {
                 JsonReference reference = factory.createSimpleReference(baseURI, node.get(PROPERTY));
                 if (reference == null) {
                     reference = factory.create(node);
@@ -57,5 +57,4 @@ public class JsonReferenceCollector {
 
         return references;
     }
-
 }

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceValidator.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceValidator.java
@@ -10,6 +10,10 @@
  *******************************************************************************/
 package com.reprezen.swagedit.core.json.references;
 
+import static com.reprezen.swagedit.core.validation.Messages.error_invalid_reference;
+import static com.reprezen.swagedit.core.validation.Messages.error_invalid_reference_type;
+import static com.reprezen.swagedit.core.validation.Messages.error_missing_reference;
+import static com.reprezen.swagedit.core.validation.Messages.warning_simple_reference;
 import static org.eclipse.core.resources.IMarker.SEVERITY_ERROR;
 import static org.eclipse.core.resources.IMarker.SEVERITY_WARNING;
 
@@ -18,15 +22,12 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.core.resources.IMarker;
-
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Sets;
 import com.reprezen.swagedit.core.editor.JsonDocument;
 import com.reprezen.swagedit.core.model.AbstractNode;
 import com.reprezen.swagedit.core.model.Model;
 import com.reprezen.swagedit.core.schema.TypeDefinition;
-import com.reprezen.swagedit.core.validation.Messages;
 import com.reprezen.swagedit.core.validation.SwaggerError;
 
 /**
@@ -58,13 +59,13 @@ public class JsonReferenceValidator {
             JsonReference reference = references.get(node);
 
             if (reference instanceof JsonReference.SimpleReference) {
-                errors.add(createReferenceError(SEVERITY_WARNING, Messages.warning_simple_reference, reference));
+                errors.add(createReferenceError(SEVERITY_WARNING, warning_simple_reference, reference));
             } else if (reference.isInvalid()) {
-                errors.add(createReferenceError(SEVERITY_ERROR, Messages.error_invalid_reference, reference));
+                errors.add(createReferenceError(SEVERITY_ERROR, error_invalid_reference, reference));
             } else if (reference.isMissing(doc, baseURI)) {
-                errors.add(createReferenceError(SEVERITY_WARNING, Messages.error_missing_reference, reference));
+                errors.add(createReferenceError(SEVERITY_WARNING, error_missing_reference, reference));
             } else if (reference.containsWarning()) {
-                errors.add(createReferenceError(SEVERITY_WARNING, Messages.error_invalid_reference, reference));
+                errors.add(createReferenceError(SEVERITY_WARNING, error_invalid_reference, reference));
             } else {
                 validateType(doc, baseURI, node, reference, errors);
             }
@@ -90,12 +91,21 @@ public class JsonReferenceValidator {
             return;
         }
 
-        Model model = doc.getModel();
-        TypeDefinition type = node.getType();
+        AbstractNode target = findTarget(doc, baseURI, reference);
+        if (!isValidType(node, target, reference)) {
+            errors.add(createReferenceError(SEVERITY_WARNING, error_invalid_reference_type, reference));
+        }
+    }
 
-        AbstractNode nodeValue = node.get(JsonReference.PROPERTY);
-        String pointer = (String) nodeValue.asValue().getValue();
-        AbstractNode valueNode = model.find(pointer);
+    protected boolean isValidType(AbstractNode source, AbstractNode target, JsonReference reference) {
+        TypeDefinition type = source.getType();
+
+        return type != null && type.validate(target);
+    }
+
+    protected AbstractNode findTarget(JsonDocument doc, URI baseURI, JsonReference reference) {
+        Model model = doc.getModel();
+        AbstractNode valueNode = model.find(reference.getPointer());
 
         if (valueNode == null) {
             // Try to load the referenced node from an external document
@@ -103,28 +113,14 @@ public class JsonReferenceValidator {
             if (externalDoc != null) {
                 try {
                     Model externalModel = Model.parse(model.getSchema(), externalDoc);
-
-                    int pos = pointer.indexOf("#");
-                    if (pos == -1) {
-                        valueNode = externalModel.getRoot();
-                    } else {
-                        valueNode = externalModel.find(pointer.substring(pos, pointer.length()));
-                    }
-
-                    if (valueNode == null) {
-                        return;
-                    }
+                    valueNode = externalModel.find(reference.getPointer());
                 } catch (Exception e) {
                     // fail to parse the model or the pointer
-                    return;
+                    return null;
                 }
             }
         }
-
-        if (!type.validate(valueNode)) {
-            errors.add(
-                    createReferenceError(IMarker.SEVERITY_WARNING, Messages.error_invalid_reference_type, reference));
-        }
+        return valueNode;
     }
 
     protected SwaggerError createReferenceError(int severity, String message, JsonReference reference) {

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceValidator.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceValidator.java
@@ -85,22 +85,16 @@ public class JsonReferenceValidator {
      * @param errors
      *            current set of errors
      */
-    private void validateType(JsonDocument doc, URI baseURI, AbstractNode node, JsonReference reference,
+    protected void validateType(JsonDocument doc, URI baseURI, AbstractNode node, JsonReference reference,
             Set<SwaggerError> errors) {
-        if (node == null) {
-            return;
-        }
 
         AbstractNode target = findTarget(doc, baseURI, reference);
-        if (!isValidType(node, target, reference)) {
+        TypeDefinition type = node.getType();
+        boolean isValidType = type != null && type.validate(target);
+
+        if (!isValidType) {
             errors.add(createReferenceError(SEVERITY_WARNING, error_invalid_reference_type, reference));
         }
-    }
-
-    protected boolean isValidType(AbstractNode source, AbstractNode target, JsonReference reference) {
-        TypeDefinition type = source.getType();
-
-        return type != null && type.validate(target);
     }
 
     protected AbstractNode findTarget(JsonDocument doc, URI baseURI, JsonReference reference) {

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/AbstractNode.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/AbstractNode.java
@@ -76,25 +76,53 @@ public abstract class AbstractNode {
      * 
      * @return true if object
      */
-    public abstract boolean isObject();
+    public boolean isObject() {
+        return false;
+    }
 
     /**
      * Returns true if the node is an array.
      * 
      * @return true if array
      */
-    public abstract boolean isArray();
+    public boolean isArray() {
+        return false;
+    }
 
+    /**
+     * Returns true if the node is a value
+     * 
+     * @return true if value
+     */
+    public boolean isValue() {
+        return false;
+    }
+
+    /**
+     * Returns the current node as an {@link ObjectNode} if it is an instance, or null otherwise.
+     * 
+     * @return node
+     */
     public ObjectNode asObject() {
-        return (ObjectNode) this;
+        return null;
     }
 
+    /**
+     * Returns the current node as an {@link ArrayNode} if it is an instance, or null otherwise.
+     * 
+     * @return node
+     */
     public ArrayNode asArray() {
-        return (ArrayNode) this;
+        return null;
     }
 
+    /**
+     * Returns the current node as an {@link ValueNode} if it is an instance, or null otherwise.
+     * 
+     * @return node
+     */
     public ValueNode asValue() {
-        return (ValueNode) this;
+        return null;
     }
 
     /**

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/ArrayNode.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/ArrayNode.java
@@ -29,8 +29,8 @@ public class ArrayNode extends AbstractNode {
     }
 
     @Override
-    public boolean isObject() {
-        return false;
+    public ArrayNode asArray() {
+        return this;
     }
 
     @Override

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/ObjectNode.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/ObjectNode.java
@@ -50,8 +50,8 @@ public class ObjectNode extends AbstractNode {
     }
 
     @Override
-    public boolean isArray() {
-        return false;
+    public ObjectNode asObject() {
+        return this;
     }
 
     @Override

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/ValueNode.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/ValueNode.java
@@ -23,13 +23,13 @@ public class ValueNode extends AbstractNode {
     }
 
     @Override
-    public boolean isObject() {
-        return false;
+    public boolean isValue() {
+        return true;
     }
 
     @Override
-    public boolean isArray() {
-        return false;
+    public ValueNode asValue() {
+        return this;
     }
 
     public Object getValue() {

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/Messages.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/Messages.java
@@ -43,6 +43,7 @@ public class Messages extends NLS {
     public static String error_scope_should_not_be_empty;
     public static String error_invalid_scope_reference;
     public static String error_invalid_operation_id;
+    public static String error_invalid_operation_ref;
 
     public static String error_array_missing_items;
     public static String error_object_type_missing;

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/messages.properties
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/messages.properties
@@ -50,6 +50,8 @@ Security requirements for oauth or openIdConnect schemes must specify a list of 
 error_invalid_scope_reference = "%s" does not match any scope name defined in the %s security scheme. 
 error_invalid_operation_id = Invalid operationId. \n\
 This operationId does not match any existing and resolvable operation.
+error_invalid_operation_ref = Invalid operationRef. \n\
+This operationRef does not match any existing and resolvable operation.
 
 # yaml
 error_yaml_parser_indentation = Unable to parse content, an incorrect indentation may be the cause.

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Mocks.java
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/utils/Mocks.java
@@ -25,9 +25,10 @@ import org.eclipse.swt.graphics.Point;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.swagedit.core.json.references.JsonDocumentManager;
 import com.reprezen.swagedit.core.json.references.JsonReference;
-import com.reprezen.swagedit.core.json.references.JsonReferenceFactory;
 import com.reprezen.swagedit.core.model.AbstractNode;
 import com.reprezen.swagedit.openapi3.editor.OpenApi3Document;
+import com.reprezen.swagedit.openapi3.validation.OpenApi3ReferenceValidator;
+import com.reprezen.swagedit.openapi3.validation.OpenApi3ReferenceValidator.OpenApi3ReferenceFactory;
 
 public class Mocks {
 
@@ -37,11 +38,11 @@ public class Mocks {
         return viewer;
     }
 
-    public static JsonReferenceFactory mockJsonReferenceFactory(final Map<URI, JsonNode> entries) {
+    public static OpenApi3ReferenceFactory mockJsonReferenceFactory(final Map<URI, JsonNode> entries) {
         final IFile file = mock(IFile.class);
         when(file.exists()).thenReturn(true);
 
-        return new JsonReferenceFactory() {
+        return new OpenApi3ReferenceValidator.OpenApi3ReferenceFactory() {
             public JsonReference create(AbstractNode node) {
                 JsonReference ref = super.create(node);
                 ref.setDocumentManager(new JsonDocumentManager() {

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
@@ -481,7 +481,7 @@ class ReferenceValidatorTest {
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
-			new SwaggerError(14, IMarker.SEVERITY_WARNING, Messages.error_invalid_reference_type)
+			new SwaggerError(14, IMarker.SEVERITY_WARNING, Messages.error_invalid_operation_ref)
 		))
 	}
 

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidationHelper.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidationHelper.xtend
@@ -4,7 +4,7 @@
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
  * http://www.eclipse.org/legal/epl-v10.html
- *
+ * 
  * Contributors:
  *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
  *******************************************************************************/
@@ -14,13 +14,11 @@ import com.fasterxml.jackson.databind.JsonNode
 import com.google.common.collect.ImmutableMap
 import com.google.common.collect.Maps
 import com.reprezen.swagedit.core.json.references.JsonDocumentManager
-import com.reprezen.swagedit.core.json.references.JsonReferenceFactory
-import com.reprezen.swagedit.core.json.references.JsonReferenceValidator
 import com.reprezen.swagedit.core.model.AbstractNode
 import com.reprezen.swagedit.core.validation.ErrorProcessor
 import com.reprezen.swagedit.core.validation.SwaggerError
-import com.reprezen.swagedit.core.validation.Validator
 import com.reprezen.swagedit.openapi3.schema.OpenApi3Schema
+import com.reprezen.swagedit.openapi3.validation.OpenApi3ReferenceValidator.OpenApi3ReferenceFactory
 import java.net.URI
 import java.util.Map
 import java.util.Set
@@ -39,7 +37,7 @@ class ValidationHelper {
 		}
 		val Map<String, JsonNode> preloadedSchemas = Maps.newHashMap();
 		preloadedSchemas.put("http://openapis.org/v3/schema.json", getSchema().getRootType().asJson());
-		new Validator(new JsonReferenceValidator(new JsonReferenceFactory()), preloadedSchemas).
+		new OpenApi3Validator(new OpenApi3ReferenceValidator(), preloadedSchemas).
 			validateAgainstSchema(processor, schemaAsJson, documentAsJson)
 	}
 
@@ -53,7 +51,7 @@ class ValidationHelper {
 				null
 			}
 		}
-		val factory = new JsonReferenceFactory() {
+		val validator = new OpenApi3ReferenceValidator(new OpenApi3ReferenceFactory() {
 			override create(AbstractNode node) {
 				val reference = super.create(node)
 				if (reference !== null) {
@@ -69,10 +67,10 @@ class ValidationHelper {
 				}
 				reference
 			}
-		}
+		})
 
 		new OpenApi3Validator(
-			new JsonReferenceValidator(factory),
+			validator,
 			ImmutableMap.of("http://openapis.org/v3/schema.json", new OpenApi3Schema().asJson)
 		)
 	}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
@@ -328,7 +328,7 @@ class ValidatorTest {
 		assertThat(
 			errors,
 			hasItems(
-				new SwaggerError(15, IMarker.SEVERITY_WARNING, Messages.error_invalid_reference_type)
+				new SwaggerError(15, IMarker.SEVERITY_WARNING, Messages.error_invalid_operation_ref)
 			)
 		)
 	}

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
@@ -324,10 +324,11 @@ class ValidatorTest {
 		document.set(content)
 		val errors = validator.validate(document, null as URI)
 		assertEquals(1, errors.size())
+
 		assertThat(
 			errors,
 			hasItems(
-				new SwaggerError(15, IMarker.SEVERITY_ERROR, Messages.error_invalid_reference_type)
+				new SwaggerError(15, IMarker.SEVERITY_WARNING, Messages.error_invalid_reference_type)
 			)
 		)
 	}

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
@@ -26,8 +26,6 @@ import com.reprezen.swagedit.core.editor.JsonEditor;
 import com.reprezen.swagedit.core.editor.JsonSourceViewerConfiguration;
 import com.reprezen.swagedit.core.hyperlinks.DefinitionHyperlinkDetector;
 import com.reprezen.swagedit.core.hyperlinks.PathParamHyperlinkDetector;
-import com.reprezen.swagedit.core.json.references.JsonReferenceFactory;
-import com.reprezen.swagedit.core.json.references.JsonReferenceValidator;
 import com.reprezen.swagedit.core.schema.CompositeSchema;
 import com.reprezen.swagedit.core.validation.Validator;
 import com.reprezen.swagedit.openapi3.Activator;
@@ -40,32 +38,32 @@ import com.reprezen.swagedit.openapi3.validation.OpenApi3Validator;
 
 public class OpenApi3Editor extends JsonEditor {
 
-	public static final String ID = "com.reprezen.swagedit.openapi3.editor";
+    public static final String ID = "com.reprezen.swagedit.openapi3.editor";
 
-	public OpenApi3Editor() {
-		super(new OpenApi3DocumentProvider(), Activator.getDefault().getPreferenceStore());
-	}
+    public OpenApi3Editor() {
+        super(new OpenApi3DocumentProvider(), Activator.getDefault().getPreferenceStore());
+    }
 
-	@Override
-	protected YEditSourceViewerConfiguration createSourceViewerConfiguration() {
-		sourceViewerConfiguration = new OpenApi3SourceViewerConfiguration();
-		sourceViewerConfiguration.setEditor(this);
-		return sourceViewerConfiguration;
-	}
+    @Override
+    protected YEditSourceViewerConfiguration createSourceViewerConfiguration() {
+        sourceViewerConfiguration = new OpenApi3SourceViewerConfiguration();
+        sourceViewerConfiguration.setEditor(this);
+        return sourceViewerConfiguration;
+    }
 
-	public static class OpenApi3SourceViewerConfiguration extends JsonSourceViewerConfiguration {
+    public static class OpenApi3SourceViewerConfiguration extends JsonSourceViewerConfiguration {
 
-		public OpenApi3SourceViewerConfiguration() {
-			super(Activator.getDefault().getPreferenceStore());
-		}
+        public OpenApi3SourceViewerConfiguration() {
+            super(Activator.getDefault().getPreferenceStore());
+        }
 
-		@Override
-		protected JsonContentAssistProcessor createContentAssistProcessor(ContentAssistant ca) {
-			return new OpenApi3ContentAssistProcessor(ca);
-		}
+        @Override
+        protected JsonContentAssistProcessor createContentAssistProcessor(ContentAssistant ca) {
+            return new OpenApi3ContentAssistProcessor(ca);
+        }
 
-		@Override
-		public IHyperlinkDetector[] getHyperlinkDetectors(ISourceViewer sourceViewer) {
+        @Override
+        public IHyperlinkDetector[] getHyperlinkDetectors(ISourceViewer sourceViewer) {
             return new IHyperlinkDetector[] { new URLHyperlinkDetector(), //
                     new PathParamHyperlinkDetector(), //
                     new DefinitionHyperlinkDetector(), //
@@ -73,26 +71,26 @@ public class OpenApi3Editor extends JsonEditor {
                     new SecuritySchemeHyperlinkDetector(), //
                     new LinkOperationHyperlinkDetector(), //
                     new LinkOperationRefHyperlinkDetector() };
-		}
+        }
 
-		@Override
-		protected CompositeSchema getSchema() {
-			return Activator.getDefault().getSchema();
-		}
+        @Override
+        protected CompositeSchema getSchema() {
+            return Activator.getDefault().getSchema();
+        }
 
-		@Override
-		protected IInformationControlCreator getOutlineInformationControlCreator() {
-			return getOutlineInformationControlCreator(OpenApi3ContentDescriber.CONTENT_TYPE_ID);
-		}
+        @Override
+        protected IInformationControlCreator getOutlineInformationControlCreator() {
+            return getOutlineInformationControlCreator(OpenApi3ContentDescriber.CONTENT_TYPE_ID);
+        }
 
-	}
+    }
 
     @Override
     protected Validator createValidator() {
         Map<String, JsonNode> preloadedSchemas = Maps.newHashMap();
-        preloadedSchemas.put("http://openapis.org/v3/schema.json",
-                Activator.getDefault().getSchema().getRootType().asJson());
-        return new OpenApi3Validator(new JsonReferenceValidator(new JsonReferenceFactory()), preloadedSchemas);
-    }
+        JsonNode schema = Activator.getDefault().getSchema().getRootType().asJson();
+        preloadedSchemas.put("http://openapis.org/v3/schema.json", schema);
 
+        return new OpenApi3Validator(preloadedSchemas);
+    }
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3ReferenceValidator.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3ReferenceValidator.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2016 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.openapi3.validation;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.core.JsonPointer;
+import com.reprezen.swagedit.core.json.references.JsonReference;
+import com.reprezen.swagedit.core.json.references.JsonReferenceFactory;
+import com.reprezen.swagedit.core.json.references.JsonReferenceValidator;
+import com.reprezen.swagedit.core.model.AbstractNode;
+import com.reprezen.swagedit.core.model.ValueNode;
+
+public class OpenApi3ReferenceValidator extends JsonReferenceValidator {
+
+    private final JsonPointer schemaPointer = JsonPointer.compile("/definitions/linkOrReference");
+    private final JsonPointer operationPointer = JsonPointer.compile("/definitions/operation");
+
+    public OpenApi3ReferenceValidator() {
+        super(new OpenApi3ReferenceFactory());
+    }
+
+    OpenApi3ReferenceValidator(OpenApi3ReferenceFactory factory) {
+        super(factory);
+    }
+
+    @Override
+    protected boolean isValidType(AbstractNode source, AbstractNode target, JsonReference reference) {
+        if (schemaPointer.equals(source.getType().getPointer())) {
+            return target != null && target.getType() != null
+                    && Objects.equals(operationPointer, target.getType().getPointer());
+        }
+        return super.isValidType(source, target, reference);
+    }
+
+    public static class OpenApi3ReferenceFactory extends JsonReferenceFactory {
+
+        private static final String OPERATION_REF = "operationRef";
+
+        @Override
+        protected Boolean isReference(AbstractNode node) {
+            return super.isReference(node) || node.get(OPERATION_REF) != null;
+        }
+
+        @Override
+        protected ValueNode getReferenceValue(AbstractNode node) {
+            ValueNode valueNode = super.getReferenceValue(node);
+            if (valueNode == null) {
+                AbstractNode other = node.get(OPERATION_REF);
+                if (other != null && other.isValue()) {
+                    valueNode = other.asValue();
+                }
+            }
+            return valueNode;
+        }
+    }
+}

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3ReferenceValidator.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3ReferenceValidator.java
@@ -24,12 +24,13 @@ import com.reprezen.swagedit.core.json.references.JsonReferenceFactory;
 import com.reprezen.swagedit.core.json.references.JsonReferenceValidator;
 import com.reprezen.swagedit.core.model.AbstractNode;
 import com.reprezen.swagedit.core.model.ValueNode;
+import com.reprezen.swagedit.core.schema.TypeDefinition;
 import com.reprezen.swagedit.core.validation.SwaggerError;
 
 public class OpenApi3ReferenceValidator extends JsonReferenceValidator {
 
-    private final JsonPointer schemaPointer = JsonPointer.compile("/definitions/linkOrReference");
-    private final JsonPointer operationPointer = JsonPointer.compile("/definitions/operation");
+    private final JsonPointer linkTypePointer = JsonPointer.compile("/definitions/linkOrReference");
+    private final JsonPointer operationTypePointer = JsonPointer.compile("/definitions/operation");
 
     public OpenApi3ReferenceValidator() {
         super(new OpenApi3ReferenceFactory());
@@ -43,10 +44,9 @@ public class OpenApi3ReferenceValidator extends JsonReferenceValidator {
     protected void validateType(JsonDocument doc, URI baseURI, AbstractNode node, JsonReference reference,
             Set<SwaggerError> errors) {
 
-        if (schemaPointer.equals(node.getType().getPointer())) {
+        if (linkTypePointer.equals(node.getType().getPointer())) {
             AbstractNode target = findTarget(doc, baseURI, reference);
-            boolean isValidType = target != null && target.getType() != null
-                    && Objects.equals(operationPointer, target.getType().getPointer());
+            boolean isValidType = isValidOperation(target);
 
             if (!isValidType) {
                 errors.add(createReferenceError(SEVERITY_WARNING, error_invalid_operation_ref, reference));
@@ -54,6 +54,12 @@ public class OpenApi3ReferenceValidator extends JsonReferenceValidator {
         } else {
             super.validateType(doc, baseURI, node, reference, errors);
         }
+    }
+
+    protected boolean isValidOperation(AbstractNode operation) {
+        TypeDefinition type = operation != null ? operation.getType() : null;
+
+        return type != null && Objects.equals(operationTypePointer, type.getPointer());
     }
 
     public static class OpenApi3ReferenceFactory extends JsonReferenceFactory {


### PR DESCRIPTION
See #306 

This one took longer than expected. I extended JsonReferenceValidator and JsonReferenceFactory (see OpenApi3ReferenceValidator) to allow them to work on OpenApi3 operationRef. This way we can reuse all code available for JSON reference validation.