### PR TITLE
[#439] Validation: Allow references to components in non-OAS files, t…

### DIFF
--- a/com.reprezen.swagedit.core/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit.core/META-INF/MANIFEST.MF
@@ -22,7 +22,11 @@ Require-Bundle: org.eclipse.ui,
  org.eclipse.ui.workbench.texteditor
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-ActivationPolicy: lazy
-Export-Package: com.reprezen.swagedit.core,
+Export-Package: com.github.fge.jsonschema.core.exceptions,
+ com.github.fge.jsonschema.core.load.configuration,
+ com.github.fge.jsonschema.core.report,
+ com.github.fge.jsonschema.main,
+ com.reprezen.swagedit.core,
  com.reprezen.swagedit.core.assist,
  com.reprezen.swagedit.core.assist.contexts,
  com.reprezen.swagedit.core.assist.ext,

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
@@ -11,7 +11,6 @@
 package com.reprezen.swagedit.openapi3.validation
 
 import com.fasterxml.jackson.databind.JsonNode
-import com.reprezen.swagedit.core.json.references.JsonReferenceValidator
 import com.reprezen.swagedit.core.validation.Messages
 import com.reprezen.swagedit.core.validation.SwaggerError
 import com.reprezen.swagedit.openapi3.editor.OpenApi3Document
@@ -31,7 +30,9 @@ class ReferenceValidatorTest {
 	val document = new OpenApi3Document(new OpenApi3Schema)
 
 	def validator(Map<URI, JsonNode> entries) {
-		new OpenApi3ReferenceValidator(Mocks.mockJsonReferenceFactory(entries))
+		val validator = new OpenApi3ReferenceValidator(Mocks.mockJsonReferenceFactory(entries))
+		validator.factory =  ValidationHelper.validator.factory
+		validator
 	}
 
 	@Test
@@ -54,7 +55,6 @@ class ReferenceValidatorTest {
 			    Valid:
 			      name: Valid
 			      in: query
-			      type: string
 		'''
 
 		document.set(content)
@@ -271,13 +271,12 @@ class ReferenceValidatorTest {
 
 	@Test
 	def void shouldValidateReference_To_ExternalFileWithValidType() {
-		val other = '''			
+		val other = '''
 			components:
 			  parameters:
 			    foo:
 			      name: foo
 			      in: query
-			      type: string
 		'''
 
 		val content = '''

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ValidatorTest.xtend
@@ -118,6 +118,9 @@ class ValidatorTest {
 			components:
 			  responses:
 			    ok:
+			      headers: 
+			        bearer:
+			          description: Bearer
 			      description: Ok
 			  schemas:
 			    Foo:

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
@@ -13,13 +13,16 @@ import org.eclipse.core.resources.IMarker
 import org.junit.Test
 
 import static org.junit.Assert.*
+import com.reprezen.swagedit.core.validation.Validator
 
 class ReferenceValidatorTest {
 
 	val document = new SwaggerDocument
 
 	def validator(Map<URI, JsonNode> entries) {
-		new JsonReferenceValidator(Mocks.mockJsonReferenceFactory(entries))
+		val validator = new JsonReferenceValidator(Mocks.mockJsonReferenceFactory(entries))
+		validator.factory = new Validator().factory
+		validator
 	}
 
 	@Test
@@ -130,6 +133,8 @@ class ReferenceValidatorTest {
 			  bar:
 			    name: bar
 			    in: path
+			    required: true
+			    type: string
 		'''
 
 		document.set(content)

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
@@ -792,16 +792,16 @@ class ValidatorTest {
 			  version: 0.0.0
 			  title: Simple API
 			paths:
-			  {}
-			
-			responses:
-			  ok:
-			    description: Ok
+			  /resource:
+			    get:
+			      responses:
+			        '200':
+			          description: OK
 			definitions:
 			  Foo:
 			    type: array
 			    items:
-			      $ref: "#/responses/ok"
+			      $ref: "#/paths/resource"
 			  Bar:
 			    type: object
 		'''


### PR DESCRIPTION
Validation: Allow references to components in non-OAS files, through any path

This commit modifies the ReferenceValidator to allow references to non OAS/Swagger files. The type validation of referenced elements is still performed but
now uses the JsonSchema validator library instead of our builtin mechanism based on JSON schema pointers. The new type validation is done by obtaining the subset of the OAS/Swagger JSON schema for which the reference is typed and validate the actual target node on it. If validation succeeds then the reference is marked as valid.