### PR TITLE
[#439] Fix reference tests

### DIFF
--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ValidatorTest.xtend
@@ -801,7 +801,7 @@ class ValidatorTest {
 			  Foo:
 			    type: array
 			    items:
-			      $ref: "#/paths/resource"
+			      $ref: "#/paths/~1resource"
 			  Bar:
 			    type: object
 		'''


### PR DESCRIPTION
Path reference in test yaml was missing '~1'