### PR TITLE
[ZEN-4172] Slow Performance, Out of Memory/GC resolving references on large Swagger project

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReference.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReference.java
@@ -232,4 +232,42 @@ public class JsonReference {
         }
     }
 
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((pointer == null) ? 0 : pointer.hashCode());
+        result = prime * result + ((uri == null) ? 0 : uri.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof JsonReference)) {
+            return false;
+        }
+        JsonReference other = (JsonReference) obj;
+        if (pointer == null) {
+            if (other.pointer != null) {
+                return false;
+            }
+        } else if (!pointer.equals(other.pointer)) {
+            return false;
+        }
+        if (uri == null) {
+            if (other.uri != null) {
+                return false;
+            }
+        } else if (!uri.equals(other.uri)) {
+            return false;
+        }
+        return true;
+    }
+
 }

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceCollector.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceCollector.java
@@ -13,8 +13,10 @@ package com.reprezen.swagedit.core.json.references;
 import static com.reprezen.swagedit.core.json.references.JsonReference.PROPERTY;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.reprezen.swagedit.core.model.AbstractNode;
 import com.reprezen.swagedit.core.model.Model;
@@ -40,8 +42,8 @@ public class JsonReferenceCollector {
      * @param model
      * @return all reference nodes
      */
-    public Map<AbstractNode, JsonReference> collect(URI baseURI, Model model) {
-        final Map<AbstractNode, JsonReference> references = Maps.newHashMap();
+    public Map<JsonReference, List<AbstractNode>> collect(URI baseURI, Model model) {
+        final Map<JsonReference, List<AbstractNode>> references = Maps.newHashMap();
 
         for (AbstractNode node : model.allNodes()) {
             if (factory.isReference(node)) {
@@ -49,8 +51,13 @@ public class JsonReferenceCollector {
                 if (reference == null) {
                     reference = factory.create(node);
                 }
+
                 if (reference != null) {
-                    references.put(node, reference);
+                    if (references.containsKey(reference)) {
+                        references.get(reference).add(node);
+                    } else {
+                        references.put(reference, Lists.newArrayList(node));
+                    }
                 }
             }
         }

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/schema/ComplexTypeDefinition.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/schema/ComplexTypeDefinition.java
@@ -12,7 +12,6 @@ package com.reprezen.swagedit.core.schema;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 
@@ -20,7 +19,6 @@ import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.google.common.collect.Iterables;
-import com.reprezen.swagedit.core.model.AbstractNode;
 
 /**
  * Represents a JSON schema type definition of a complex type, eg oneOf, allOf, anyOf types.
@@ -107,40 +105,6 @@ public class ComplexTypeDefinition extends TypeDefinition {
         }
     }
 
-    @Override
-    public boolean validate(AbstractNode valueNode) {
-        if (valueNode == null) {
-            return false;
-        }
-
-        TypeDefinition valueType = valueNode.getType();
-        if (valueType == null) {
-            return false;
-        }
-
-        if (valueType instanceof ReferenceTypeDefinition) {
-            valueType = ((ReferenceTypeDefinition) valueType).resolve();
-        }
-
-        boolean isValid = this == valueType;
-
-        if (isValid) {
-            return true;
-        }
-
-        Iterator<TypeDefinition> it = getComplexTypes().iterator();
-        while (it.hasNext() && !isValid) {
-            TypeDefinition current = it.next();
-
-            if (current.getPointer() != null && valueType != null
-                    && current.getPointer().equals(valueType.getPointer())) {
-                isValid = true;
-            }
-        }
-
-        return isValid;
-    }
-    
     @Override
     public String getLabel() {
         TypeDefinition firstType = Iterables.getFirst(complexTypes, null);

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/schema/ReferenceTypeDefinition.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/schema/ReferenceTypeDefinition.java
@@ -13,7 +13,6 @@ package com.reprezen.swagedit.core.schema;
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.reprezen.swagedit.core.json.references.JsonReference;
-import com.reprezen.swagedit.core.model.AbstractNode;
 
 /**
  * Represents a JSON reference that should be resolved as a type definition.
@@ -62,11 +61,6 @@ public class ReferenceTypeDefinition extends TypeDefinition {
     @Override
     public TypeDefinition getPropertyType(String property) {
         return resolve().getPropertyType(property);
-    }
-
-    @Override
-    public boolean validate(AbstractNode valueNode) {
-        return resolve().validate(valueNode);
     }
     
     @Override

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/schema/TypeDefinition.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/schema/TypeDefinition.java
@@ -12,7 +12,6 @@ package com.reprezen.swagedit.core.schema;
 
 import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.reprezen.swagedit.core.model.AbstractNode;
 
 /**
  * Represents a type defined inside a JSON Schema.
@@ -97,23 +96,6 @@ public class TypeDefinition {
     protected static String getProperty(JsonPointer pointer) {
         String s = pointer.toString();
         return s.substring(s.lastIndexOf("/") + 1).replaceAll("~1", "/");
-    }
-
-    public boolean validate(AbstractNode valueNode) {
-        if (valueNode == null) {
-            return false;
-        }
-
-        TypeDefinition valueType = valueNode.getType();
-        if (valueType == null) {
-            return false;
-        }
-
-        if (valueType instanceof ReferenceTypeDefinition) {
-            valueType = ((ReferenceTypeDefinition) valueType).resolve();
-        }
-
-        return this == valueType;
     }
 
 }

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3ReferenceValidator.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/validation/OpenApi3ReferenceValidator.java
@@ -10,31 +10,30 @@
  *******************************************************************************/
 package com.reprezen.swagedit.openapi3.validation;
 
+import static com.reprezen.swagedit.core.validation.Messages.error_invalid_operation_ref;
+import static com.reprezen.swagedit.core.validation.Messages.error_invalid_reference_type;
+
 import java.net.URI;
-import java.util.Objects;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
-import org.eclipse.core.resources.IMarker;
-
-import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.github.fge.jsonschema.core.exceptions.ProcessingException;
-import com.github.fge.jsonschema.core.report.ProcessingReport;
 import com.github.fge.jsonschema.main.JsonSchema;
+import com.google.common.collect.Sets;
 import com.reprezen.swagedit.core.editor.JsonDocument;
 import com.reprezen.swagedit.core.json.references.JsonReference;
 import com.reprezen.swagedit.core.json.references.JsonReferenceFactory;
 import com.reprezen.swagedit.core.json.references.JsonReferenceValidator;
 import com.reprezen.swagedit.core.model.AbstractNode;
 import com.reprezen.swagedit.core.model.ValueNode;
-import com.reprezen.swagedit.core.schema.TypeDefinition;
-import com.reprezen.swagedit.core.validation.Messages;
 import com.reprezen.swagedit.core.validation.SwaggerError;
 
 public class OpenApi3ReferenceValidator extends JsonReferenceValidator {
 
-    private final JsonPointer linkTypePointer = JsonPointer.compile("/definitions/linkOrReference");
-    private final JsonPointer operationTypePointer = JsonPointer.compile("/definitions/operation");
+    private final String linkTypePointer = "/definitions/linkOrReference";
+    private final String operationTypePointer = "/definitions/operation";
 
     public OpenApi3ReferenceValidator() {
         super(new OpenApi3ReferenceFactory());
@@ -45,34 +44,24 @@ public class OpenApi3ReferenceValidator extends JsonReferenceValidator {
     }
 
     @Override
-    protected void validateType(JsonDocument doc, URI baseURI, AbstractNode node, JsonReference reference,
-            Set<SwaggerError> errors) {
+    protected Set<SwaggerError> validateType(JsonDocument doc, URI baseURI, JsonReference reference,
+            Collection<AbstractNode> sources, Map<String, JsonSchema> schemas) {
 
-        if (linkTypePointer.equals(node.getType().getPointer())) {
-            JsonNode target = findTarget(doc, baseURI, reference);
+        Set<SwaggerError> errors = Sets.newHashSet();
+        Map<String, List<AbstractNode>> sourceTypes = groupSourcesByType(sources);
+        JsonNode target = findTarget(doc, baseURI, reference);
 
-            if (factory != null) {
-                JsonSchema jsonSchema;
-                try {
-                    jsonSchema = factory.getJsonSchema(doc.getSchema().asJson(), operationTypePointer.toString());
-                    ProcessingReport report = jsonSchema.validate(target);
-                    if (!report.isSuccess()) {
-                        errors.add(createReferenceError(IMarker.SEVERITY_WARNING, Messages.error_invalid_operation_ref,
-                                reference));
-                    }
-                } catch (ProcessingException e) {
-                    e.printStackTrace();
-                }
-            }
-        } else {
-            super.validateType(doc, baseURI, node, reference, errors);
+        for (String type : sourceTypes.keySet()) {
+            boolean isOperationValidation = linkTypePointer.equals(type);
+
+            String ptr = isOperationValidation ? operationTypePointer.toString() : type;
+            String message = isOperationValidation ? error_invalid_operation_ref : error_invalid_reference_type;
+
+            JsonSchema jsonSchema = getSchema(doc, ptr, schemas);
+            errors.addAll(validate(jsonSchema, target, message, sourceTypes.get(type)));
         }
-    }
 
-    protected boolean isValidOperation(AbstractNode operation) {
-        TypeDefinition type = operation != null ? operation.getType() : null;
-
-        return type != null && Objects.equals(operationTypePointer, type.getPointer());
+        return errors;
     }
 
     public static class OpenApi3ReferenceFactory extends JsonReferenceFactory {
@@ -95,5 +84,6 @@ public class OpenApi3ReferenceValidator extends JsonReferenceValidator {
             }
             return valueNode;
         }
+
     }
 }


### PR DESCRIPTION
This PR optimises the validation of references by avoiding running the validation on each of them, but rather by collecting references in a document inside a Set from which validation will be performed. With avoid like that running validation on similar references more than once. It also reduces the number of call to JSON schema validator for validation of references types by caching sub schemas and making groups of identical types on which only a single validation is performed.

@tedepstein @andylowry This PR should improve performance on large specs quite a bit. What more could be done is to avoid performing expensive validation (such as type validation) on each document changes (maybe only on save). The validation is currently performed in a separate job, maybe their would be a way to cancel that job when another validation is initiated.