### PR TITLE
#431 Recognizers often ascribe wrong file type

### DIFF
--- a/com.reprezen.swagedit.openapi3/plugin.xml
+++ b/com.reprezen.swagedit.openapi3/plugin.xml
@@ -20,16 +20,13 @@
    <extension
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
-            base-type="org.eclipse.core.runtime.text"
+            base-type="org.dadacoalition.yedit.yamlsource"
             describer="com.reprezen.swagedit.openapi3.editor.OpenApi3ContentDescriber"
             file-extensions="yaml"
             default-charset="UTF-8"
             id="com.reprezen.swagedit.contenttype.openapi3.yaml"
             name="%content-type.name"
             priority="high">
-         <describer
-               class="com.reprezen.swagedit.editor.SwaggerContentDescriber">
-         </describer>
       </content-type>
    </extension>
    

--- a/com.reprezen.swagedit/plugin.xml
+++ b/com.reprezen.swagedit/plugin.xml
@@ -36,16 +36,13 @@
    <extension
          point="org.eclipse.core.contenttype.contentTypes">
       <content-type
-            base-type="org.eclipse.core.runtime.text"
+            base-type="org.dadacoalition.yedit.yamlsource"
             describer="com.reprezen.swagedit.editor.SwaggerContentDescriber"
             file-extensions="yaml"
             default-charset="UTF-8"
             id="com.reprezen.swagedit.contenttype.swagger.yaml"
             name="%content-type.name"
             priority="high">
-         <describer
-               class="com.reprezen.swagedit.editor.SwaggerContentDescriber">
-         </describer>
       </content-type>
    </extension>
 


### PR DESCRIPTION
Fix contentType for an empty YAML file, now it returns a more generic
YEdit editor.
Why this fix works

1. An empty file always returns `INDETERMINATE` as description. Note
that it's not the `VALID` which is returned when a content describer
actually accepts the input. See
`com.reprezen.swagedit.core.editor.TextContentDescriber.describe(InputStream,
IContentDescription)`:
```
        String content = CharStreams.toString(new
InputStreamReader(contents));
        if (content.trim().isEmpty()) {
            return INDETERMINATE;
        }

        return isSupported(content) ? VALID : INVALID;
```
2. All ContentDescriber for a given file extensions are equally
important.
Because all the ContentDescriber return `INDETERMINATE`, they are
treated equally important, see
`org.eclipse.core.internal.content.ContentTypeCatalog.collectMatchingByContents(int,
IContentType[], List<ContentType>, ILazySource, Map<String, Object>)`

3. Then `IContentType` are sorted and the first one wins
`org.eclipse.core.internal.content.ContentTypeCatalog.internalFindContentTypesFor(ILazySource,
IContentType[][], Comparator<IContentType>, Comparator<IContentType>)`
sorts the inputs. In case of `INDETERMINATE`,
`ContentTypeCatalog.policyConstantGeneralIsBetter` is used which is...
> A sorting policy where the more generic content type wins.
Lexicographical comparison is done as a last resort when all other
criteria fail.

where more generic content type means, `getDepth()` is based on the
hierarchy defined by the `base-type`:
```
// first criteria: depth - the lower, the better
int depthCriteria = type1.getDepth() - type2.getDepth();
```

--------


By using YEdit as the `base-type`, we make the YEdit the more generic
content type => it will be used in case of empty files.