### PR TITLE
ZEN-4176 Prevent validation from running multiple times

### DIFF
--- a/com.reprezen.swagedit.core/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: com.reprezen.swagedit.core;singleton:=true
 Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: ModelSolv, Inc. d.b.a. RepreZen
 Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime;bundle-version="3.13.0",
+ org.eclipse.core.runtime,
  org.eclipse.ui.editors,
  org.eclipse.jface.text,
  org.dadacoalition.yedit,

--- a/com.reprezen.swagedit.core/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit.core/META-INF/MANIFEST.MF
@@ -5,7 +5,7 @@ Bundle-SymbolicName: com.reprezen.swagedit.core;singleton:=true
 Bundle-Version: 0.8.0.qualifier
 Bundle-Vendor: ModelSolv, Inc. d.b.a. RepreZen
 Require-Bundle: org.eclipse.ui,
- org.eclipse.core.runtime,
+ org.eclipse.core.runtime;bundle-version="3.13.0",
  org.eclipse.ui.editors,
  org.eclipse.jface.text,
  org.dadacoalition.yedit,

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/ValidationOperation.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/ValidationOperation.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2018 ModelSolv, Inc. and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *    ModelSolv, Inc. - initial API and implementation and/or initial documentation
+ *******************************************************************************/
+package com.reprezen.swagedit.core.editor;
+
+import java.util.Set;
+
+import org.dadacoalition.yedit.YEditLog;
+import org.eclipse.core.resources.IFile;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.ICoreRunnable;
+import org.eclipse.core.runtime.IProgressMonitor;
+import org.eclipse.core.runtime.SubMonitor;
+import org.eclipse.jface.text.IDocument;
+import org.eclipse.ui.IEditorInput;
+import org.eclipse.ui.IFileEditorInput;
+import org.eclipse.ui.texteditor.IDocumentProvider;
+import org.yaml.snakeyaml.error.YAMLException;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.reprezen.swagedit.core.validation.SwaggerError;
+import com.reprezen.swagedit.core.validation.Validator;
+
+public class ValidationOperation implements ICoreRunnable {
+
+    private final Validator validator;
+
+    private final IEditorInput editorInput;
+    private final IDocumentProvider documentProvider;
+    private final boolean parseFileContents;
+
+    public ValidationOperation(Validator validator, IEditorInput editorInput, IDocumentProvider documentProvider,
+            boolean parseFileContents) {
+        this.validator = validator;
+        this.editorInput = editorInput;
+        this.documentProvider = documentProvider;
+        this.parseFileContents = parseFileContents;
+    }
+
+    @Override
+    public void run(IProgressMonitor monitor) throws CoreException {
+        // if the file is not part of a workspace it does not seems that it is a
+        // IFileEditorInput
+        // but instead a FileStoreEditorInput. Unclear if markers are valid for
+        // such files.
+        if (!(editorInput instanceof IFileEditorInput)) {
+            YEditLog.logError("Marking errors not supported for files outside of a project.");
+            YEditLog.logger.info("editorInput is not a part of a project.");
+            return;
+        }
+
+        final IDocument document = documentProvider.getDocument(editorInput);
+        if (document instanceof JsonDocument) {
+            SubMonitor subMonitor = SubMonitor.convert(monitor, 100);
+            final IFileEditorInput fileEditorInput = (IFileEditorInput) editorInput;
+            final IFile file = fileEditorInput.getFile();
+
+            if (parseFileContents) {
+                // force parsing of yaml to init parsing errors
+                // subMonitor.split() should NOT be executed before this code
+                // as it checks for job cancellation and we want to be sure that 
+                // the document is parsed on opening
+                ((JsonDocument) document).onChange();
+            }
+            subMonitor.split(20);
+            JsonEditor.clearMarkers(file);
+            subMonitor.split(30);
+            validateYaml(file, (JsonDocument) document);
+            subMonitor.split(20);
+            validateSwagger(file, (JsonDocument) document, fileEditorInput);
+            subMonitor.split(30);
+        }
+    }
+
+    protected void validateYaml(IFile file, JsonDocument document) {
+        if (document.getYamlError() instanceof YAMLException) {
+            JsonEditor.addMarker(SwaggerError.newYamlError((YAMLException) document.getYamlError()), file, document);
+        }
+        if (document.getJsonError() instanceof JsonProcessingException) {
+            JsonEditor.addMarker(SwaggerError.newJsonError((JsonProcessingException) document.getJsonError()), file,
+                    document);
+        }
+    }
+
+    protected void validateSwagger(IFile file, JsonDocument document, IFileEditorInput editorInput) {
+        final Set<SwaggerError> errors = validator.validate(document, editorInput);
+
+        for (SwaggerError error : errors) {
+            JsonEditor.addMarker(error, file, document);
+        }
+    }
+
+    public IEditorInput getEditorInput() {
+        return editorInput;
+    }
+
+}

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -10,7 +10,10 @@
  *******************************************************************************/
 package com.reprezen.swagedit.editor;
 
+import org.dadacoalition.yedit.YEditLog;
 import org.dadacoalition.yedit.editor.YEditSourceViewerConfiguration;
+import org.eclipse.core.runtime.CoreException;
+import org.eclipse.core.runtime.NullProgressMonitor;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
 
@@ -37,7 +40,11 @@ public class SwaggerEditor extends JsonEditor {
                 boolean newValue = event.getNewValue() instanceof Boolean ? (Boolean) event.getNewValue()
                         : Boolean.valueOf((String) event.getNewValue());
                 Activator.getDefault().getSchema().allowJsonRefInContext(event.getProperty(), newValue);
-                validate();
+                try {
+                    createValidationOperation(false).run(new NullProgressMonitor());
+                } catch (CoreException e) {
+                    YEditLog.logException(e);
+                }
             }
         }
     };


### PR DESCRIPTION
The "Update KaiZen Editor validation markers" job now cancels other
validations on the current file if a new validation is initiated.

In general, validation is invoked:
* Inside a bigger WorkspaceJob on save(), saveAs(), and validation
preferences change for Swagger v2
* As an individual WorkspaceJob "Update KaiZen Editor validation
markers" on document opening (`setInput()`) and
change(`documentChanged()`)

Extracted a lightweight `ValidationOperation` which:
* Cancellable
* Provides more accurate progress report