### PR TITLE
ZEN-4351 Invalid Thread Access Exception thrown when saving document and other fixes

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/JsonEditor.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/JsonEditor.java
@@ -104,16 +104,18 @@ public abstract class JsonEditor extends YEdit implements IShowInSource, IShowIn
             if (event.getDocument() instanceof JsonDocument) {
                 final JsonDocument document = (JsonDocument) event.getDocument();
 
+                document.onChange();
                 Display.getCurrent().asyncExec(new Runnable() {
                     @Override
                     public void run() {
-                        document.onChange();
                         if (contentOutline != null) {
+                            // depends on the results of document.onChange()
                             contentOutline.setInput(getEditorInput());
                         }
-                        runValidate(false);
                     }
                 });
+                // depends on the results of document.onChange()
+                runValidate(false);
             }
         }
     };

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/JsonEditor.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/editor/JsonEditor.java
@@ -340,7 +340,11 @@ public abstract class JsonEditor extends YEdit implements IShowInSource, IShowIn
                         }
                     });
                 }
-                createValidationOperation(false).run(monitor);
+                // ZEN-4351 Invalid Thread Access Exception thrown when saving documents
+                // Don't use the same monitor for the validation as it makes checks for monitor.isCancelled()
+                // The monitor passed to the doSave() operation is `EventLoopProgressMonitor` whose operations
+                // must run in the Main thread
+                runValidate(false);
                 return Status.OK_STATUS;
             }
         }.schedule();
@@ -366,7 +370,11 @@ public abstract class JsonEditor extends YEdit implements IShowInSource, IShowIn
                         }
                     });
                 }
-                createValidationOperation(false).run(monitor);
+                // ZEN-4351 Invalid Thread Access Exception thrown when saving documents
+                // Don't use the same monitor for the validation as it makes checks for monitor.isCancelled()
+                // The monitor passed to the doSave() operation is `EventLoopProgressMonitor` whose operations
+                // must run in the Main thread
+                runValidate(false);
                 return Status.OK_STATUS;
             }
         }.schedule();

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceValidator.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/json/references/JsonReferenceValidator.java
@@ -35,6 +35,7 @@ import com.reprezen.swagedit.core.Activator;
 import com.reprezen.swagedit.core.editor.JsonDocument;
 import com.reprezen.swagedit.core.model.AbstractNode;
 import com.reprezen.swagedit.core.model.Location;
+import com.reprezen.swagedit.core.model.Model;
 import com.reprezen.swagedit.core.validation.SwaggerError;
 
 /**
@@ -63,8 +64,8 @@ public class JsonReferenceValidator {
      * @param document
      * @return collection of errors
      */
-    public Collection<? extends SwaggerError> validate(URI baseURI, JsonDocument doc) {
-        return doValidate(baseURI, doc, collector.collect(baseURI, doc.getModel()));
+    public Collection<? extends SwaggerError> validate(URI baseURI, JsonDocument doc, Model model) {
+        return doValidate(baseURI, doc, collector.collect(baseURI, model));
     }
 
     /*

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/Validator.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/Validator.java
@@ -126,12 +126,13 @@ public class Validator {
 
         if (jsonContent != null) {
             Node yaml = document.getYaml();
-            if (yaml != null) {
+            Model model = document.getModel();
+            if (yaml != null && model != null) {
                 errors.addAll(validateAgainstSchema(
                         new ErrorProcessor(yaml, document.getSchema().getRootType().getContent()), document));
-                errors.addAll(validateModel(document.getModel()));
+                errors.addAll(validateModel(model));
                 errors.addAll(checkDuplicateKeys(yaml));
-                errors.addAll(referenceValidator.validate(baseURI, document));
+                errors.addAll(referenceValidator.validate(baseURI, document, model));
             }
         }
 

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/validation/ReferenceValidatorTest.xtend
@@ -60,7 +60,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/components/parameters/Valid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(0, errors.size())
 	}
@@ -89,7 +89,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/components/schemas/Valid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())		
 		assertTrue(errors.contains(
@@ -117,7 +117,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/components/parameters/Invalid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -150,7 +150,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/components/parameters/bar")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(0, errors.size())
 	}
@@ -175,7 +175,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/paths/~1foo~1{bar}")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(new SwaggerError(9, IMarker.SEVERITY_WARNING, Messages.error_invalid_reference)))
@@ -201,7 +201,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/paths/~1foo")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -233,7 +233,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -261,7 +261,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml")
-		val errors = validator(#{otherURI -> null}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> null}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -297,7 +297,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml#/components/parameters/foo")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document, document.model)
 
 		errors.forEach[println(it.message)]
 		assertEquals(0, errors.size())
@@ -330,7 +330,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml#/info/version")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -365,7 +365,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml#/info/foo")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -392,7 +392,7 @@ class ReferenceValidatorTest {
 
 		document.set(content)
 		val baseURI = new URI(null, null, null)
-		val errors = validator(#{}).validate(baseURI, document)
+		val errors = validator(#{}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -421,7 +421,7 @@ class ReferenceValidatorTest {
 
 		document.set(content)
 		val baseURI = new URI(null, null, null)
-		val errors = validator(#{}).validate(baseURI, document)
+		val errors = validator(#{}).validate(baseURI, document, document.model)
 
 		assertEquals(0, errors.size())
 	}
@@ -447,7 +447,7 @@ class ReferenceValidatorTest {
 
 		document.set(content)
 		val baseURI = new URI(null, null, null)
-		val errors = validator(#{}).validate(baseURI, document)
+		val errors = validator(#{}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -476,7 +476,7 @@ class ReferenceValidatorTest {
 
 		document.set(content)
 		val baseURI = new URI(null, null, null)
-		val errors = validator(#{}).validate(baseURI, document)
+		val errors = validator(#{}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/validation/ReferenceValidatorTest.xtend
@@ -50,7 +50,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/definitions/Valid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(0, errors.size())
 	}
@@ -78,7 +78,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/definitions/Valid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())		
 		assertTrue(errors.contains(
@@ -106,7 +106,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/definitions/Invalid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -140,7 +140,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/parameters/bar")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(0, errors.size())
 	}
@@ -165,7 +165,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/paths/~1foo~1{bar}")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(new SwaggerError(9, IMarker.SEVERITY_WARNING, Messages.error_invalid_reference)))
@@ -191,7 +191,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/paths/~1foo")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -223,7 +223,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -251,7 +251,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml")
-		val errors = validator(#{otherURI -> null}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> null}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -287,7 +287,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml#/parameters/foo")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(0, errors.size())
 	}
@@ -319,7 +319,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml#/info/version")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -354,7 +354,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val otherURI = URI.create("other.yaml#/info/foo")
-		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document)
+		val errors = validator(#{otherURI -> other.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -381,7 +381,7 @@ class ReferenceValidatorTest {
 
 		document.set(content)
 		val baseURI = new URI(null, null, null)
-		val errors = validator(#{}).validate(baseURI, document)
+		val errors = validator(#{}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertTrue(errors.contains(
@@ -412,7 +412,7 @@ class ReferenceValidatorTest {
 		document.set(content)
 		val baseURI = new URI(null, null, null)
 		val resolvedURI = new URI(null, null, "/definitions/Valid")
-		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document)
+		val errors = validator(#{resolvedURI -> document.asJson}).validate(baseURI, document, document.model)
 
 		assertEquals(1, errors.size())
 		assertEquals(Messages.warning_simple_reference, errors.get(0).message)


### PR DESCRIPTION
Improvements:
* Don't run validation in UI thread as it worsens the user experience
* Make JsonDocument's `model`, `jsonContent`, and `yamlContent` multi-thread safe
* Fix potential NPE by only passing non-null Model to `JsonReferenceValidator`


# ZEN-4351 Invalid Thread Access Exception thrown when saving documents
## Monitor.isCancelled() and the Main Thread.
Normally, monitor.isCancelled() should NOT be executed in the Main
thread - that's the idea of the progress monitor.

However, the save operations use a special implementation of the
progress monitor (`EventLoopProgressMonitor`)  which is 
> used to run an event loop whenever progress monitor methods are
invoked

That's why `isCancelled()` operation must be executed in the Main Thread
for this implementation of the monitor. 

`org.eclipse.ui.internal.SaveableHelper.saveModels()` creates and
`EventLoopProgressMonitor`, then it calls `doSaveModel()` which calls
the editor's save method (`model.doSave(subMonitor.split(2),
shellProvider);`). This is how our `doSave()` methods gets this
implementation of the monitor and passes it to the validation.

