### PR TITLE
#459 - remove dependency on javax.mail

### DIFF
--- a/com.reprezen.swagedit.openapi3/META-INF/MANIFEST.MF
+++ b/com.reprezen.swagedit.openapi3/META-INF/MANIFEST.MF
@@ -24,8 +24,7 @@ Require-Bundle: org.eclipse.ui,
  org.apache.log4j;bundle-version="1.2.15",
  com.reprezen.jsonoverlay;bundle-version="3.1.0",
  com.reprezen.kaizen.openapi-parser;bundle-version="3.0.1",
- com.norconex.commons.norconex-commons-lang;bundle-version="1.15.0",
- javax.mail-api;bundle-version="1.6.1"
+ com.norconex.commons.norconex-commons-lang;bundle-version="1.15.0"
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy
 Export-Package: com.reprezen.swagedit.openapi3,


### PR DESCRIPTION
Note: I wasn't able to reproduce the issue reported in #459 on my Mac. The issue was initially found on Windows.

`javax.mail` is only used in the `validateEmailField()` method which is used by `ContactValidator`.
Validation showed correct results on a Contact object when the `email` value was correct and when it was incorrect. 

I tested the update site created with this change and didn't have any problems in validation of `Contact` or other elements. 
