### PR TITLE
ZEN-4361 Missing marker location indicators (Overview Ruler) next to editor scrollbar in KZOE

### DIFF
--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/editor/OpenApi3Editor.java
@@ -15,12 +15,15 @@ import static com.reprezen.swagedit.openapi3.preferences.OpenApi3PreferenceConst
 import java.util.Map;
 
 import org.dadacoalition.yedit.editor.YEditSourceViewerConfiguration;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.text.IInformationControlCreator;
 import org.eclipse.jface.text.contentassist.ContentAssistant;
 import org.eclipse.jface.text.hyperlink.IHyperlinkDetector;
 import org.eclipse.jface.text.hyperlink.URLHyperlinkDetector;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.util.IPropertyChangeListener;
+import org.eclipse.ui.internal.editors.text.EditorsPlugin;
+import org.eclipse.ui.texteditor.ChainedPreferenceStore;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.Maps;
@@ -55,7 +58,12 @@ public class OpenApi3Editor extends JsonEditor {
     };
 
     public OpenApi3Editor() {
-        super(new OpenApi3DocumentProvider(), Activator.getDefault().getPreferenceStore());
+        super(new OpenApi3DocumentProvider(), //
+                // ZEN-4361 Missing marker location indicators (Overview Ruler) next to editor scrollbar in KZOE
+                new ChainedPreferenceStore(new IPreferenceStore[] { //
+                        Activator.getDefault().getPreferenceStore(), //
+                        // Preferences store for EditorsPlugin has settings to show/hide the rules and markers
+                        EditorsPlugin.getDefault().getPreferenceStore() }));
     }
 
     @Override

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/editor/SwaggerEditor.java
@@ -14,8 +14,11 @@ import org.dadacoalition.yedit.YEditLog;
 import org.dadacoalition.yedit.editor.YEditSourceViewerConfiguration;
 import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.NullProgressMonitor;
+import org.eclipse.jface.preference.IPreferenceStore;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.jface.util.PropertyChangeEvent;
+import org.eclipse.ui.internal.editors.text.EditorsPlugin;
+import org.eclipse.ui.texteditor.ChainedPreferenceStore;
 
 import com.reprezen.swagedit.Activator;
 import com.reprezen.swagedit.core.editor.JsonEditor;
@@ -52,7 +55,12 @@ public class SwaggerEditor extends JsonEditor {
     };
   
     public SwaggerEditor() {
-        super(new SwaggerDocumentProvider(), Activator.getDefault().getPreferenceStore());
+        super(new SwaggerDocumentProvider(), //
+                // ZEN-4361 Missing marker location indicators (Overview Ruler) next to editor scrollbar in KZOE
+                new ChainedPreferenceStore(new IPreferenceStore[] { //
+                        Activator.getDefault().getPreferenceStore(), //
+                        // Preferences store for EditorsPlugin has settings to show/hide the rules and markers
+                        EditorsPlugin.getDefault().getPreferenceStore() }));
     }
     
     @Override


### PR DESCRIPTION
Preferences store for EditorsPlugin has settings to show/hide the rules
and markers. 
We were using EditorsPlugin's preferences store before commit
e63addb99483563426d75c4e4b6ecfc98cf47d96 when we replaced it by our
editor's pref store. This commit uses a composite (chained) preferences
store which has read access to both EditorsPlugin and KZOE editor's
editor stores and writes values to the KZOE editor's prefs.