### PR TITLE
[#469] Fix Object resource template

### DIFF
--- a/com.reprezen.swagedit.openapi3/resources/templates.xml
+++ b/com.reprezen.swagedit.openapi3/resources/templates.xml
@@ -54,7 +54,7 @@ email: ${contact_email}</template>
        id="com.reprezen.swagedit.openapi3.templates.object_resource_template" 
        description="object resource template" 
        context="com.reprezen.swagedit.openapi3.templates.paths" 
-       enabled="true">/${item}s/${id}:
+       enabled="true">/${item}s/{${id}}:
   get:
     description: Get an ${item} with the given ID
     parameters:
@@ -70,7 +70,7 @@ email: ${contact_email}</template>
         content:
           application/json:
             schema:
-              $$ref: '${itemSchema}' 
+              $$ref: "${itemSchema}" 
       '404':
         description: Not Found
   patch:
@@ -128,7 +128,7 @@ email: ${contact_email}</template>
             schema:
               type: array
               items:
-                $$ref: '${itemSchema}' 
+                $$ref: "${itemSchema}" 
   post:
     description: Create a new ${item}
     requestBody:
@@ -159,7 +159,7 @@ email: ${contact_email}</template>
         content:
           application/json:
             schema:
-              $$ref: '${itemSchema}' 
+              $$ref: "${itemSchema}" 
   put:
     description: Create a new ${item}
     requestBody:
@@ -214,7 +214,7 @@ email: ${contact_email}</template>
           schema:
             type: array
             items:
-              $$ref: '${itemSchema}'</template>
+              $$ref: "${itemSchema}"</template>
 
 	<template name="get" 
        id="com.reprezen.swagedit.openapi3.templates.path_get_on_object_template" 
@@ -235,7 +235,7 @@ email: ${contact_email}</template>
       content:
         application/json:
           schema:
-            $$ref: '${itemSchema}' 
+            $$ref: "${itemSchema}" 
     '404':
       description: Not Found</template>
             
@@ -465,7 +465,7 @@ properties:
        description="ALL OF schema definition" 
        context="com.reprezen.swagedit.openapi3.templates.schema" 
        enabled="true">allOf:
-- $$ref: '${schema1}'
+- $$ref: "${schema1}"
 - type: object
   properties:
     ${name}:
@@ -476,7 +476,7 @@ properties:
        description="ANY OF schema definition" 
        context="com.reprezen.swagedit.openapi3.templates.schema" 
        enabled="true">anyOf:
-- $$ref: '${schema1}'
+- $$ref: "${schema1}"
 - type: object
   properties:
     ${name}:
@@ -487,7 +487,7 @@ properties:
        description="ONE OF schema definition" 
        context="com.reprezen.swagedit.openapi3.templates.schema" 
        enabled="true">oneOf:
-- $$ref: '${schema1}'
+- $$ref: "${schema1}"
 - type: object
   properties:
     ${name}:
@@ -544,7 +544,7 @@ items:
           content: 
             'application/json':
               schema:
-                $$ref: '${schema}'
+                $$ref: "${schema}"
         responses:
           '200':
             description: webhook successfully processed</template>
@@ -568,11 +568,11 @@ items:
             schema:
               type: array
               items:
-                $$ref: '${responseModel}'
+                $$ref: "${responseModel}"
       default:
         description: Error
         content:
           'text/html':
             schema:
-              $$ref: '${errorModel}'</template>            
+              $$ref: "${errorModel}"</template>
 </templates>


### PR DESCRIPTION
This realates to issue ZEN-4367 RepreZen JIRA

The `Object resource` template does not work well with reference string
content-assist when filling in its `itemSchema` placeholder. The first
instance of the placeholder is fine, but the next one has an extra quote
in front of the ref string. This appears to be a problem with the
content-assist implementation, not something that can be addressed by
changing the template. So this commit does not fix the reported problem.

However, while investigating this issue, another bug in that template
came to light, namely that the path parameter specified via the "id"
plaaceholder in the template ends up without needed braces in the path
string. This causes corresponding parameter definitions in contained
operations to be in error.

This commit fixes the path string issue, but as to the reference string
issue, it only makes quoting of ref strings consistent throughout the
templates. Where ref strings are quoted, they are now always quoted with
double quotes, whereas before there appeared to be a somewhat random use
of double or single quotes.