### PR TITLE
[ZEN-4529] KZOE: Quick outline view with filter duplicates outline branches

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/AbstractNode.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/AbstractNode.java
@@ -260,7 +260,8 @@ public abstract class AbstractNode {
         if (getClass() != obj.getClass())
             return false;
         AbstractNode other = (AbstractNode) obj;
-        return Objects.equals(getPointer(), other.getPointer());
+
+        return Objects.equals(getModel(), other.getModel()) && Objects.equals(getPointer(), other.getPointer());
     }
 
 }

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/Model.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/model/Model.java
@@ -23,6 +23,7 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.core.resources.IFile;
 import org.eclipse.core.runtime.IPath;
@@ -408,6 +409,24 @@ public class Model {
      */
     public CompositeSchema getSchema() {
         return schema;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(nodes, path);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (!(obj instanceof Model))
+            return false;
+
+        Model other = (Model) obj;
+        return Objects.equals(other.path, path);
     }
 
 }


### PR DESCRIPTION
The quick outline tree showed duplicates because equality of nodes was not implemented correctly, so the tree could not filter the nodes.


Before:
![screen shot 2019-01-16 at 12 23 59](https://user-images.githubusercontent.com/148045/51246078-c7835e00-1989-11e9-9c95-befd5d1dd9fa.png)


After:
![screen shot 2019-01-16 at 12 22 30](https://user-images.githubusercontent.com/148045/51246089-cd793f00-1989-11e9-9504-80f4a629666b.png)


