### PR TITLE
[ZEN-4499] KZOE Editor: Typeahead doesn't filter code templates correctly

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/StyledTemplateProposal.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/StyledTemplateProposal.java
@@ -26,7 +26,6 @@ public class StyledTemplateProposal extends TemplateProposal implements IComplet
             StyledString styledString, int relevance) {
         super(template, context, region, image, relevance);
         this.styledString = styledString;
-        System.out.println("StyledTemplateProposal: " + styledString);
     }
 
     @Override

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceProposalProvider_Quotes_Test.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/JsonReferenceProposalProvider_Quotes_Test.xtend
@@ -158,7 +158,7 @@ components:
 	}
 
 	val processor = new OpenApi3ContentAssistProcessor(null, referenceProvider) {
-		override protected initTextMessages(Model model) { new ArrayList }
+		override protected initTextMessages() { new ArrayList }
 
 		override protected getContextTypeRegistry() { null }
 

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessorTest.xtend
@@ -25,7 +25,7 @@ import com.reprezen.swagedit.core.model.Model
 class OpenApi3ContentAssistProcessorTest {
 
 	val processor = new OpenApi3ContentAssistProcessor(null, new OpenApi3Schema) {
-		override protected initTextMessages(Model model) { new ArrayList }
+		override protected initTextMessages() { new ArrayList }
 
 		override protected getContextTypeRegistry() { null }
 

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
@@ -8,12 +8,11 @@ import static com.reprezen.swagedit.tests.utils.Cursors.*
 import static org.hamcrest.core.IsCollectionContaining.*
 import static org.junit.Assert.*
 import com.reprezen.swagedit.core.assist.StyledCompletionProposal
-import com.reprezen.swagedit.core.model.Model
 
 class SwaggerContentAssistProcessorTest {
 
 	val processor = new SwaggerContentAssistProcessor(null) {
-		override protected initTextMessages(Model model) {
+		override protected initTextMessages() {
 			new ArrayList
 		}
 


### PR DESCRIPTION
This PR adds filtering of template proposals during typeahead. The filter returns the template proposals for which the display string contains the current typeahead string.

Screencasts:

Swagger:
![s1](https://user-images.githubusercontent.com/148045/51312831-7ab48b80-1a4c-11e9-9dfa-c9731e998eb1.gif)

OpenAPI
![s2](https://user-images.githubusercontent.com/148045/51312834-7c7e4f00-1a4c-11e9-8f35-9b8feb535744.gif)

![s3](https://user-images.githubusercontent.com/148045/51312837-7d16e580-1a4c-11e9-8968-ec1e0ec6b2ea.gif)
