### PR TITLE
[ZEN-4782] Example Validation: Use error severity for schema validation failures

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/providers/ValidationProvider.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/providers/ValidationProvider.java
@@ -13,8 +13,6 @@ package com.reprezen.swagedit.core.providers;
 import java.net.URI;
 import java.util.Set;
 
-import org.eclipse.jface.preference.IPreferenceStore;
-
 import com.reprezen.swagedit.core.editor.JsonDocument;
 import com.reprezen.swagedit.core.model.AbstractNode;
 import com.reprezen.swagedit.core.validation.SwaggerError;
@@ -46,10 +44,8 @@ public interface ValidationProvider {
      * 
      * @param document
      *            being validated.
-     * @param preferenceStore
-     *            holding all preferences.
      * @return true if validator is active.
      */
-    boolean isActive(JsonDocument document, IPreferenceStore preferenceStore);
+    boolean isActive(JsonDocument document);
 
 }

--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/Validator.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/validation/Validator.java
@@ -129,7 +129,8 @@ public abstract class Validator {
                 executeModelValidation(model, node, errors);
                 // execute validation from each providers
                 providers.forEach(provider -> {
-                    if (provider.isActive(document, getPreferenceStore())) {
+
+                    if (provider.isActive(document)) {
                         Set<SwaggerError> result = provider.validate(document, baseURI, node);
                         if (result != null) {
                             errors.addAll(result);

--- a/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/preferences/OpenApi3ValidationPreferences.java
+++ b/com.reprezen.swagedit.openapi3/src/com/reprezen/swagedit/openapi3/preferences/OpenApi3ValidationPreferences.java
@@ -47,15 +47,24 @@ public class OpenApi3ValidationPreferences extends FieldEditorPreferencePage
 
     @Override
     protected void createFieldEditors() {
-        Composite composite = new Composite(getFieldEditorParent(), SWT.NONE);
-        GridLayoutFactory.fillDefaults().applyTo(composite);
-        GridDataFactory.fillDefaults().grab(true, false).indent(0, 10).applyTo(composite);
+        Composite parent = new Composite(getFieldEditorParent(), SWT.NONE);
 
-        addField(new BooleanFieldEditor(ADVANCED_VALIDATION, "Enable advanced validation", composite));
+        GridLayoutFactory.fillDefaults() //
+                .numColumns(2) //
+                .margins(5, 8) //
+                .spacing(5, 20) //
+                .applyTo(parent);
+
+        // Should wrap the fields in a composite to allow use of spacing.
+        {
+            Composite composite = new Composite(parent, SWT.NONE);
+            GridDataFactory.fillDefaults().span(2, 1).applyTo(composite);
+            addField(new BooleanFieldEditor(ADVANCED_VALIDATION, "Enable advanced validation", composite));
+        }
 
         Set<PreferenceProvider> providers = ExtensionUtils.getPreferenceProviders(VALIDATION_PREFERENCE_PAGE);
         providers.forEach(provider -> {
-            for (FieldEditor field : provider.createFields(Version.OPENAPI, composite)) {
+            for (FieldEditor field : provider.createFields(Version.OPENAPI, parent)) {
                 addField(field);
             }
         });

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
@@ -25,6 +25,7 @@ import org.eclipse.jface.preference.FieldEditor;
 import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.swt.SWT;
+import org.eclipse.swt.layout.GridLayout;
 import org.eclipse.swt.widgets.Composite;
 import org.eclipse.swt.widgets.Group;
 import org.eclipse.ui.IWorkbench;
@@ -62,6 +63,7 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage
 
         Group group = new Group(composite, SWT.SHADOW_ETCHED_IN);
         GridDataFactory.fillDefaults().span(2, 1).applyTo(group);
+
         group.setText("Allow JSON references in additional contexts");
 
         addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, "Security Definitions Object",
@@ -71,6 +73,10 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage
                 group));
         addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, "Security Requirement Object",
                 group));
+
+        // FieldEditor set parent layout to GridLayout with margin = 0
+        ((GridLayout) group.getLayout()).marginTop = 8;
+        ((GridLayout) group.getLayout()).marginLeft = 8;
 
         // Validation
 

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
@@ -26,7 +26,7 @@ import org.eclipse.jface.preference.FieldEditorPreferencePage;
 import org.eclipse.jface.util.IPropertyChangeListener;
 import org.eclipse.swt.SWT;
 import org.eclipse.swt.widgets.Composite;
-import org.eclipse.swt.widgets.Label;
+import org.eclipse.swt.widgets.Group;
 import org.eclipse.ui.IWorkbench;
 import org.eclipse.ui.IWorkbenchPreferencePage;
 
@@ -43,7 +43,7 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage
         // FieldEditorParent, but to its child
         super(FieldEditorPreferencePage.GRID);
         setPreferenceStore(Activator.getDefault().getPreferenceStore());
-        setDescription("Swagger preferences for validation");
+        setDescription("Swagger preferences for validation:");
     }
 
     @Override
@@ -53,8 +53,24 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage
     @Override
     protected void createFieldEditors() {
         Composite composite = new Composite(getFieldEditorParent(), SWT.NONE);
-        GridLayoutFactory.fillDefaults().applyTo(composite);
-        GridDataFactory.fillDefaults().grab(true, false).indent(0, 10).applyTo(composite);
+
+        GridLayoutFactory.fillDefaults() //
+                .numColumns(2) //
+                .margins(5, 8) //
+                .spacing(5, 20) //
+                .applyTo(composite);
+
+        Group group = new Group(composite, SWT.SHADOW_ETCHED_IN);
+        GridDataFactory.fillDefaults().span(2, 1).applyTo(group);
+        group.setText("Allow JSON references in additional contexts");
+
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, "Security Definitions Object",
+                group));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_SCHEME_OBJECT, "Security Scheme Object", group));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, "Security Requirements Array",
+                group));
+        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, "Security Requirement Object",
+                group));
 
         // Validation
 
@@ -64,32 +80,6 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage
                 addField(field);
             }
         });
-
-        // IMPORTANT: FieldEditorPreferencePage does not work very well with complex
-        // layouts and nested widgets.
-        // Consider switching to
-        // com.modelsolv.reprezen.generators.ui.preferences.GroupedFieldEditorPreferencePage
-        // from
-        // the RepreZen repo before modifying it
-        Composite refValidationComposite = new Composite(composite, SWT.BORDER);
-        GridLayoutFactory.fillDefaults().margins(5, 5).applyTo(refValidationComposite);
-        GridDataFactory.fillDefaults().grab(true, false).applyTo(refValidationComposite);
-
-        Label header = new Label(refValidationComposite, SWT.NONE);
-        header.setText("Allow JSON references in additional contexts:");
-
-        Composite fieldComposite = new Composite(refValidationComposite, SWT.NONE);
-        GridLayoutFactory.fillDefaults().margins(8, 8).applyTo(fieldComposite);
-        GridDataFactory.fillDefaults().grab(true, false).applyTo(fieldComposite);
-
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_DEFINITIONS_OBJECT, "Security Definitions Object",
-                fieldComposite));
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_SCHEME_OBJECT, "Security Scheme Object",
-                fieldComposite));
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENTS_ARRAY, "Security Requirements Array",
-                fieldComposite));
-        addField(new BooleanFieldEditor(VALIDATION_REF_SECURITY_REQUIREMENT_OBJECT, "Security Requirement Object",
-                fieldComposite));
     }
 
 }

--- a/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
+++ b/com.reprezen.swagedit/src/com/reprezen/swagedit/preferences/SwaggerValidationPreferences.java
@@ -76,7 +76,9 @@ public class SwaggerValidationPreferences extends FieldEditorPreferencePage
 
         // FieldEditor set parent layout to GridLayout with margin = 0
         ((GridLayout) group.getLayout()).marginTop = 8;
+        ((GridLayout) group.getLayout()).marginBottom = 8;
         ((GridLayout) group.getLayout()).marginLeft = 8;
+        ((GridLayout) group.getLayout()).marginRight = 8;
 
         // Validation
 


### PR DESCRIPTION
Update preferences to allow users to select the level of validation for examples.