### PR TITLE
[#496 / ZEN-4808] Code assist is missing properties named "default"

### DIFF
--- a/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonProposalProvider.java
+++ b/com.reprezen.swagedit.core/src/com/reprezen/swagedit/core/assist/JsonProposalProvider.java
@@ -149,7 +149,7 @@ public class JsonProposalProvider {
     }
 
     protected ProposalDescriptor createPropertyProposal(String key, TypeDefinition type) {
-        if (type == null || "default".equals(key)) {
+        if (type == null) {
             return null;
         }
 

--- a/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.openapi3.tests/src/com/reprezen/swagedit/openapi3/assist/OpenApi3ContentAssistProcessorTest.xtend
@@ -527,4 +527,21 @@ components:
 		)
 	}
 
+	@Test
+	def void testSchema_ShouldHaveDefaultProperty() {
+		val document = new OpenApi3Document(new OpenApi3Schema)
+		val test = setUpContentAssistTest('''
+			components:
+			  schemas:
+			    Pet:
+			      <1>
+		''', document)
+
+		val proposals = test.apply(processor, "1")
+
+		assertThat(
+			proposals.map[(it as StyledCompletionProposal).replacementString],
+			hasItem("default:")
+		)
+	}
 }

--- a/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
+++ b/com.reprezen.swagedit.tests/src/com/reprezen/swagedit/assist/SwaggerContentAssistProcessorTest.xtend
@@ -185,7 +185,7 @@ class SwaggerContentAssistProcessorTest {
 
 		var proposals = test.apply(processor, "1")
 		var values = proposals.map[(it as StyledCompletionProposal).replacementString]
-		assertEquals(30, values.size)
+		assertEquals(31, values.size)
 		assertThat(values, hasItems(
 			"$ref:", 
 			"format:", 
@@ -216,12 +216,13 @@ class SwaggerContentAssistProcessorTest {
 			"xml:", 
 			"externalDocs:", 
 			"example:", 
+			"default:",
 			"x-:"))
 
 		proposals = test.apply(processor, "2")
 		values = proposals.map[(it as StyledCompletionProposal).replacementString]
 		// same without required and properties
-		assertEquals(28, values.size)
+		assertEquals(29, values.size)
 		assertThat(values, hasItems(
 			"$ref:", 
 			"format:", 
@@ -250,6 +251,7 @@ class SwaggerContentAssistProcessorTest {
 			"xml:", 
 			"externalDocs:", 
 			"example:", 
+			"default:",
 			"x-:"))
 		
 		proposals = test.apply(processor, "3")


### PR DESCRIPTION
Addresses #496 .