### PR TITLE
[ZEN-5019] CRITICAL: KZOE Release Broken with Checksum Errors on Install

### DIFF
--- a/com.reprezen.swagedit.repository/pom.xml
+++ b/com.reprezen.swagedit.repository/pom.xml
@@ -20,6 +20,7 @@
 					<includeAllDependencies>true</includeAllDependencies>
 					<createArtifactRepository>true</createArtifactRepository>
 					<compress>true</compress>
+					<xzCompress>false</xzCompress>
 				</configuration>
 			</plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 	</modules>
 
 	<properties>
-		<tycho.version>1.4.0</tycho.version>
+		<tycho.version>0.23.1</tycho.version>
 		<xtend-maven-plugin.version>2.17.0</xtend-maven-plugin.version>
 		<target-platform-artifact-id>com.reprezen.swagedit.target</target-platform-artifact-id>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Disable xz compresssion so that the update site does not include any xml.xz files and uses previous layout prior to tycho update.